### PR TITLE
Fix: implement /api/activities/recent endpoint for dashboard activity feed

### DIFF
--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -1,22 +1,57 @@
-const { MaintenanceRequest, Equipment, MaintenanceTeam, TeamMember } = require('../models');
+const {
+  MaintenanceRequest,
+  Equipment,
+  MaintenanceTeam,
+  TeamMember,
+} = require("../models");
+const { logActivity } = require("../utils/logActivity");
+
+// Remove empty-string ObjectId/date fields so Mongoose validation doesn't fail
+const sanitizeBody = (body) => {
+  const cleaned = { ...body };
+
+  const objectIdFields = [
+    "equipmentId",
+    "teamId",
+    "assignedToId",
+    "createdById",
+  ];
+  objectIdFields.forEach((f) => {
+    if (cleaned[f] === "" || cleaned[f] === null) delete cleaned[f];
+  });
+
+  if (cleaned.scheduledDate === "" || cleaned.scheduledDate === null)
+    delete cleaned.scheduledDate;
+  if (cleaned.completedDate === "" || cleaned.completedDate === null)
+    delete cleaned.completedDate;
+
+  return cleaned;
+};
+
+const getDisplayName = (doc, fallback = "") => {
+  if (!doc) return fallback;
+  return doc.name || doc.title || doc.requestNumber || fallback;
+};
 
 // Generate request number
 const generateRequestNumber = async () => {
   const date = new Date();
   const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, "0");
 
   const regex = new RegExp(`^REQ-${year}${month}-`);
-  const lastRequest = await MaintenanceRequest.findOne({ requestNumber: { $regex: regex } }).sort({ requestNumber: -1 });
+  const lastRequest = await MaintenanceRequest.findOne({
+    requestNumber: { $regex: regex },
+  }).sort({ requestNumber: -1 });
 
   let sequence = 1;
   if (lastRequest && lastRequest.requestNumber) {
-    const parts = lastRequest.requestNumber.split('-');
-    const lastSequence = parseInt(parts[2] || '0', 10);
+    const parts = lastRequest.requestNumber.split("-");
+    const lastSequence = parseInt(parts[2] || "0", 10);
     if (!isNaN(lastSequence)) sequence = lastSequence + 1;
   }
 
-  return `REQ-${year}${month}-${String(sequence).padStart(4, '0')}`;
+  return `REQ-${year}${month}-${String(sequence).padStart(4, "0")}`;
 };
 
 // Get all requests
@@ -30,11 +65,12 @@ exports.getAllRequests = async (req, res) => {
     if (teamId) where.teamId = teamId;
 
     const requests = await MaintenanceRequest.find(where)
-      .populate('equipment')
-      .populate('team')
-      .populate('assignedTo')
-      .populate('createdBy')
+      .populate("equipment")
+      .populate("team")
+      .populate("assignedTo")
+      .populate("createdBy")
       .sort({ createdAt: -1 });
+
     res.json(requests);
   } catch (error) {
     res.status(500).json({ error: error.message });
@@ -45,12 +81,12 @@ exports.getAllRequests = async (req, res) => {
 exports.getRequestById = async (req, res) => {
   try {
     const request = await MaintenanceRequest.findById(req.params.id)
-      .populate('equipment')
-      .populate('team')
-      .populate('assignedTo')
-      .populate('createdBy');
+      .populate("equipment")
+      .populate("team")
+      .populate("assignedTo")
+      .populate("createdBy");
 
-    if (!request) return res.status(404).json({ error: 'Request not found' });
+    if (!request) return res.status(404).json({ error: "Request not found" });
     res.json(request);
   } catch (error) {
     res.status(500).json({ error: error.message });
@@ -60,28 +96,75 @@ exports.getRequestById = async (req, res) => {
 // Create request with auto-fill logic
 exports.createRequest = async (req, res) => {
   try {
+    const payload = sanitizeBody(req.body);
     const requestNumber = await generateRequestNumber();
 
-    if (req.body.equipmentId) {
-      const equipment = await Equipment.findById(req.body.equipmentId)
-        .populate('maintenanceTeam')
-        .populate('defaultTechnician');
+    let equipmentDoc = null;
+    let oldEquipmentStatus = null;
 
-      if (equipment) {
-        if (!req.body.teamId && equipment.maintenanceTeamId) req.body.teamId = equipment.maintenanceTeamId;
-        if (!req.body.assignedToId && equipment.defaultTechnicianId) req.body.assignedToId = equipment.defaultTechnicianId;
+    if (payload.equipmentId) {
+      equipmentDoc = await Equipment.findById(payload.equipmentId)
+        .populate("maintenanceTeam")
+        .populate("defaultTechnician");
 
-        await Equipment.findByIdAndUpdate(equipment._id, { status: 'under-maintenance' });
+      if (equipmentDoc) {
+        oldEquipmentStatus = equipmentDoc.status;
+
+        if (!payload.teamId && equipmentDoc.maintenanceTeamId)
+          payload.teamId = equipmentDoc.maintenanceTeamId;
+        if (!payload.assignedToId && equipmentDoc.defaultTechnicianId)
+          payload.assignedToId = equipmentDoc.defaultTechnicianId;
+
+        await Equipment.findByIdAndUpdate(equipmentDoc._id, {
+          status: "under-maintenance",
+        });
       }
     }
 
-    const request = await MaintenanceRequest.create({ ...req.body, requestNumber });
+    const request = await MaintenanceRequest.create({
+      ...payload,
+      requestNumber,
+    });
 
     const requestWithRelations = await MaintenanceRequest.findById(request._id)
-      .populate('equipment')
-      .populate('team')
-      .populate('assignedTo')
-      .populate('createdBy');
+      .populate("equipment")
+      .populate("team")
+      .populate("assignedTo")
+      .populate("createdBy");
+
+    const userName = requestWithRelations?.createdBy?.name || "";
+
+    // Activity: request created
+    await logActivity({
+      type: "request_created",
+      title: "New Maintenance Request",
+      description: `${getDisplayName(requestWithRelations.equipment)} - ${requestWithRelations.subject || requestWithRelations.requestNumber}`,
+      userName,
+      metadata: {
+        priority: requestWithRelations.priority,
+        stage: requestWithRelations.stage,
+        requestNumber: requestWithRelations.requestNumber,
+      },
+      entityType: "request",
+      entityId: String(requestWithRelations._id),
+    });
+
+    // Activity: equipment status changed (if we changed it)
+    if (
+      equipmentDoc &&
+      oldEquipmentStatus &&
+      oldEquipmentStatus !== "under-maintenance"
+    ) {
+      await logActivity({
+        type: "equipment_updated",
+        title: "Equipment Status Changed",
+        description: `${equipmentDoc.name} - Status changed to under-maintenance`,
+        userName,
+        metadata: { from: oldEquipmentStatus, to: "under-maintenance" },
+        entityType: "equipment",
+        entityId: String(equipmentDoc._id),
+      });
+    }
 
     res.status(201).json(requestWithRelations);
   } catch (error) {
@@ -92,27 +175,80 @@ exports.createRequest = async (req, res) => {
 // Update request
 exports.updateRequest = async (req, res) => {
   try {
-    const request = await MaintenanceRequest.findById(req.params.id);
-    if (!request) return res.status(404).json({ error: 'Request not found' });
+    const payload = sanitizeBody(req.body);
 
-    if (req.body.stage) {
-      if (req.body.stage === 'repaired') {
-        req.body.completedDate = new Date();
-        if (request.equipmentId) await Equipment.findByIdAndUpdate(request.equipmentId, { status: 'active' });
+    const request = await MaintenanceRequest.findById(req.params.id)
+      .populate("equipment")
+      .populate("createdBy");
+
+    if (!request) return res.status(404).json({ error: "Request not found" });
+
+    const prevStage = request.stage;
+    const prevPriority = request.priority;
+
+    // Handle stage side-effects (equipment status updates)
+    if (payload.stage) {
+      if (payload.stage === "repaired") {
+        payload.completedDate = new Date();
+        if (request.equipmentId)
+          await Equipment.findByIdAndUpdate(request.equipmentId, {
+            status: "active",
+          });
       }
-      if (req.body.stage === 'scrap') {
-        req.body.completedDate = new Date();
-        if (request.equipmentId) await Equipment.findByIdAndUpdate(request.equipmentId, { status: 'scrapped' });
+      if (payload.stage === "scrap") {
+        payload.completedDate = new Date();
+        if (request.equipmentId)
+          await Equipment.findByIdAndUpdate(request.equipmentId, {
+            status: "scrapped",
+          });
       }
     }
 
-    await MaintenanceRequest.findByIdAndUpdate(req.params.id, req.body);
+    await MaintenanceRequest.findByIdAndUpdate(req.params.id, payload);
 
     const updatedRequest = await MaintenanceRequest.findById(req.params.id)
-      .populate('equipment')
-      .populate('team')
-      .populate('assignedTo')
-      .populate('createdBy');
+      .populate("equipment")
+      .populate("team")
+      .populate("assignedTo")
+      .populate("createdBy");
+
+    const userName = updatedRequest?.createdBy?.name || "";
+    const newStage = updatedRequest.stage;
+    const completed = newStage === "repaired" || newStage === "scrap";
+
+    await logActivity({
+      type: completed ? "request_completed" : "request_updated",
+      title: completed ? "Request Completed" : "Request Updated",
+      description: `${getDisplayName(updatedRequest.equipment)} - ${updatedRequest.subject || updatedRequest.requestNumber}`,
+      userName,
+      metadata: {
+        priority: updatedRequest.priority,
+        prevPriority,
+        prevStage,
+        stage: newStage,
+        requestNumber: updatedRequest.requestNumber,
+      },
+      entityType: "request",
+      entityId: String(updatedRequest._id),
+    });
+
+    // If equipment status changed due to stage update, log it too
+    if (
+      request.equipment &&
+      payload.stage &&
+      (payload.stage === "repaired" || payload.stage === "scrap")
+    ) {
+      const toStatus = payload.stage === "scrap" ? "scrapped" : "active";
+      await logActivity({
+        type: "equipment_updated",
+        title: "Equipment Status Changed",
+        description: `${request.equipment.name} - Status changed to ${toStatus}`,
+        userName,
+        metadata: { to: toStatus },
+        entityType: "equipment",
+        entityId: String(request.equipment._id),
+      });
+    }
 
     res.json(updatedRequest);
   } catch (error) {
@@ -124,23 +260,64 @@ exports.updateRequest = async (req, res) => {
 exports.updateRequestStage = async (req, res) => {
   try {
     const { stage } = req.body;
-    const request = await MaintenanceRequest.findById(req.params.id);
-    if (!request) return res.status(404).json({ error: 'Request not found' });
+    const request = await MaintenanceRequest.findById(req.params.id)
+      .populate("equipment")
+      .populate("createdBy");
+
+    if (!request) return res.status(404).json({ error: "Request not found" });
+
+    const prevStage = request.stage;
 
     await MaintenanceRequest.findByIdAndUpdate(req.params.id, { stage });
 
-    if (stage === 'repaired' || stage === 'scrap') {
-      await MaintenanceRequest.findByIdAndUpdate(req.params.id, { completedDate: new Date() });
+    if (stage === "repaired" || stage === "scrap") {
+      await MaintenanceRequest.findByIdAndUpdate(req.params.id, {
+        completedDate: new Date(),
+      });
       if (request.equipmentId) {
-        const newStatus = stage === 'scrap' ? 'scrapped' : 'active';
-        await Equipment.findByIdAndUpdate(request.equipmentId, { status: newStatus });
+        const newStatus = stage === "scrap" ? "scrapped" : "active";
+        await Equipment.findByIdAndUpdate(request.equipmentId, {
+          status: newStatus,
+        });
       }
     }
 
     const updatedRequest = await MaintenanceRequest.findById(req.params.id)
-      .populate('equipment')
-      .populate('team')
-      .populate('assignedTo');
+      .populate("equipment")
+      .populate("team")
+      .populate("assignedTo")
+      .populate("createdBy");
+
+    const userName = updatedRequest?.createdBy?.name || "";
+    const completed = stage === "repaired" || stage === "scrap";
+
+    await logActivity({
+      type: completed ? "request_completed" : "request_updated",
+      title: completed ? "Request Completed" : "Request Updated",
+      description: `${getDisplayName(updatedRequest.equipment)} - ${updatedRequest.subject || updatedRequest.requestNumber}`,
+      userName,
+      metadata: {
+        priority: updatedRequest.priority,
+        prevStage,
+        stage,
+        requestNumber: updatedRequest.requestNumber,
+      },
+      entityType: "request",
+      entityId: String(updatedRequest._id),
+    });
+
+    if (updatedRequest.equipment && completed) {
+      const toStatus = stage === "scrap" ? "scrapped" : "active";
+      await logActivity({
+        type: "equipment_updated",
+        title: "Equipment Status Changed",
+        description: `${updatedRequest.equipment.name} - Status changed to ${toStatus}`,
+        userName,
+        metadata: { to: toStatus },
+        entityType: "equipment",
+        entityId: String(updatedRequest.equipment._id),
+      });
+    }
 
     res.json(updatedRequest);
   } catch (error) {
@@ -151,9 +328,25 @@ exports.updateRequestStage = async (req, res) => {
 // Delete request
 exports.deleteRequest = async (req, res) => {
   try {
-    const request = await MaintenanceRequest.findByIdAndDelete(req.params.id);
-    if (!request) return res.status(404).json({ error: 'Request not found' });
-    res.json({ message: 'Request deleted successfully' });
+    const request = await MaintenanceRequest.findByIdAndDelete(req.params.id)
+      .populate("equipment")
+      .populate("createdBy");
+
+    if (!request) return res.status(404).json({ error: "Request not found" });
+
+    const userName = request?.createdBy?.name || "";
+
+    await logActivity({
+      type: "request_updated",
+      title: "Request Deleted",
+      description: `${getDisplayName(request.equipment)} - ${request.subject || request.requestNumber}`,
+      userName,
+      metadata: { requestNumber: request.requestNumber },
+      entityType: "request",
+      entityId: String(request._id),
+    });
+
+    res.json({ message: "Request deleted successfully" });
   } catch (error) {
     res.status(500).json({ error: error.message });
   }
@@ -163,15 +356,15 @@ exports.deleteRequest = async (req, res) => {
 exports.getCalendarEvents = async (req, res) => {
   try {
     const { start, end } = req.query;
-    const where = { type: 'preventive' };
+    const where = { type: "preventive" };
 
     if (start && end) {
       where.scheduledDate = { $gte: new Date(start), $lte: new Date(end) };
     }
 
     const requests = await MaintenanceRequest.find(where)
-      .populate('equipment')
-      .populate('assignedTo');
+      .populate("equipment")
+      .populate("assignedTo");
 
     res.json(requests);
   } catch (error) {

--- a/server/index.js
+++ b/server/index.js
@@ -1,66 +1,68 @@
-const express = require('express');
-const cors = require('cors');
-const morgan = require('morgan');
-const bodyParser = require('body-parser');
-require('dotenv').config();
+const express = require("express");
+const activitiesRoutes = require("./routes/activities");
+const cors = require("cors");
+const morgan = require("morgan");
+const bodyParser = require("body-parser");
+require("dotenv").config();
 
-const { syncDatabase } = require('./models');
-const equipmentRoutes = require('./routes/equipment');
-const teamRoutes = require('./routes/teams');
-const memberRoutes = require('./routes/members');
-const requestRoutes = require('./routes/requests');
+const { syncDatabase } = require("./models");
+const equipmentRoutes = require("./routes/equipment");
+const teamRoutes = require("./routes/teams");
+const memberRoutes = require("./routes/members");
+const requestRoutes = require("./routes/requests");
 
 const app = express();
 const PORT = process.env.PORT || 5000;
 
 // Middleware
 app.use(cors());
-app.use(morgan('dev'));
+app.use(morgan("dev"));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
 // Routes
-app.use('/api/equipment', equipmentRoutes);
-app.use('/api/teams', teamRoutes);
-app.use('/api/members', memberRoutes);
-app.use('/api/requests', requestRoutes);
+app.use("/api/equipment", equipmentRoutes);
+app.use("/api/teams", teamRoutes);
+app.use("/api/members", memberRoutes);
+app.use("/api/requests", requestRoutes);
+app.use("/api/activities", activitiesRoutes); // ✅ added
 
 // Health check
-app.get('/api/health', (req, res) => {
-  res.json({ 
-    status: 'OK', 
-    message: 'GearGuard API is running',
-    timestamp: new Date().toISOString()
+app.get("/api/health", (req, res) => {
+  res.json({
+    status: "OK",
+    message: "GearGuard API is running",
+    timestamp: new Date().toISOString(),
   });
 });
 
 // Error handling middleware
 app.use((err, req, res, next) => {
   console.error(err.stack);
-  res.status(500).json({ 
-    error: 'Something went wrong!',
-    message: process.env.NODE_ENV === 'development' ? err.message : undefined
+  res.status(500).json({
+    error: "Something went wrong!",
+    message: process.env.NODE_ENV === "development" ? err.message : undefined,
   });
 });
 
 // 404 handler
 app.use((req, res) => {
-  res.status(404).json({ error: 'Route not found' });
+  res.status(404).json({ error: "Route not found" });
 });
 
 // Initialize database and start server
 const startServer = async () => {
   try {
     await syncDatabase();
-    
+
     app.listen(PORT, () => {
       console.log(`\n🚀 GearGuard Server Running!`);
       console.log(`📡 API: http://localhost:${PORT}/api`);
       console.log(`💚 Health: http://localhost:${PORT}/api/health`);
-      console.log(`🌍 Environment: ${process.env.NODE_ENV || 'development'}\n`);
+      console.log(`🌍 Environment: ${process.env.NODE_ENV || "development"}\n`);
     });
   } catch (error) {
-    console.error('Failed to start server:', error);
+    console.error("Failed to start server:", error);
     process.exit(1);
   }
 };

--- a/server/models/Activity.js
+++ b/server/models/Activity.js
@@ -1,0 +1,39 @@
+const mongoose = require("mongoose");
+
+const ActivitySchema = new mongoose.Schema(
+  {
+    type: {
+      type: String,
+      required: true,
+      enum: [
+        "request_created",
+        "request_updated",
+        "request_completed",
+        "equipment_updated",
+        "team_assigned",
+        "member_added",
+      ],
+      index: true,
+    },
+    title: { type: String, required: true, trim: true },
+    description: { type: String, required: true, trim: true },
+
+    // No auth system in repo currently, so keep it optional
+    userName: { type: String, default: "", trim: true },
+
+    // flexible extra info like priority, ids, etc.
+    metadata: { type: mongoose.Schema.Types.Mixed, default: {} },
+
+    // optional: useful for filtering later
+    entityType: {
+      type: String,
+      enum: ["request", "equipment", "team", "member"],
+      default: null,
+      index: true,
+    },
+    entityId: { type: String, default: null, index: true },
+  },
+  { timestamps: true }, // gives createdAt/updatedAt
+);
+
+module.exports = mongoose.model("Activity", ActivitySchema);

--- a/server/routes/activities.js
+++ b/server/routes/activities.js
@@ -1,0 +1,71 @@
+const express = require("express");
+const router = express.Router();
+const Activity = require("../models/Activity");
+
+// GET /api/activities/recent?limit=15
+router.get("/recent", async (req, res) => {
+  const limitRaw = parseInt(req.query.limit, 10);
+  const limit = Number.isFinite(limitRaw)
+    ? Math.min(Math.max(limitRaw, 1), 100)
+    : 15;
+
+  const activities = await Activity.find({})
+    .sort({ createdAt: -1 })
+    .limit(limit)
+    .lean();
+
+  // Map _id/createdAt to frontend expected fields
+  const payload = activities.map((a) => ({
+    id: String(a._id),
+    type: a.type,
+    title: a.title,
+    description: a.description,
+    userName: a.userName || "",
+    timestamp: a.createdAt
+      ? new Date(a.createdAt).toISOString()
+      : new Date().toISOString(),
+    metadata: a.metadata || {},
+  }));
+
+  res.json(payload);
+});
+
+// (Optional for Activity page later)
+// GET /api/activities?limit=50&skip=0&type=request_created
+router.get("/", async (req, res) => {
+  const limitRaw = parseInt(req.query.limit, 10);
+  const skipRaw = parseInt(req.query.skip, 10);
+
+  const limit = Number.isFinite(limitRaw)
+    ? Math.min(Math.max(limitRaw, 1), 200)
+    : 50;
+  const skip = Number.isFinite(skipRaw) ? Math.max(skipRaw, 0) : 0;
+
+  const filter = {};
+  if (req.query.type) filter.type = req.query.type;
+  if (req.query.entityType) filter.entityType = req.query.entityType;
+
+  const items = await Activity.find(filter)
+    .sort({ createdAt: -1 })
+    .skip(skip)
+    .limit(limit)
+    .lean();
+  const total = await Activity.countDocuments(filter);
+
+  res.json({
+    total,
+    items: items.map((a) => ({
+      id: String(a._id),
+      type: a.type,
+      title: a.title,
+      description: a.description,
+      userName: a.userName || "",
+      timestamp: a.createdAt
+        ? new Date(a.createdAt).toISOString()
+        : new Date().toISOString(),
+      metadata: a.metadata || {},
+    })),
+  });
+});
+
+module.exports = router;

--- a/server/utils/logActivity.js
+++ b/server/utils/logActivity.js
@@ -1,0 +1,32 @@
+const Activity = require("../models/Activity");
+
+/**
+ * Non-blocking activity logger:
+ * If activity logging fails, it should NOT break the main API flow.
+ */
+async function logActivity({
+  type,
+  title,
+  description,
+  userName = "",
+  metadata = {},
+  entityType = null,
+  entityId = null,
+}) {
+  try {
+    await Activity.create({
+      type,
+      title,
+      description,
+      userName,
+      metadata,
+      entityType,
+      entityId,
+    });
+  } catch (err) {
+    // Don't throw: logging should never break the main operation
+    console.error("Activity logging failed:", err.message);
+  }
+}
+
+module.exports = { logActivity };


### PR DESCRIPTION
Fixes #<ISSUE_NUMBER>

### What I changed
- Added Activity model and non-blocking logger utility
- Implemented `GET /api/activities/recent?limit=...`
- Wired `/api/activities` routes into the server
- Logged `request_created` activity on request creation
- Sanitized empty-string ObjectId fields (equipmentId/teamId/assignedToId) to avoid Mongoose cast errors

### How to test
1. Run `npm run dev`
2. Create a maintenance request from the UI
3. Open: `http://localhost:5000/api/activities/recent?limit=5` (should return 200 with activity items)
4. Dashboard "Team Activity" should load without 404/Axios errors