### PR TITLE
fix: resolve technician autofill issue caused by incorrect member filtering   fix -:#5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 PORT=5000
-MONGO_URI=mongodb+srv://gearcard2025:gearcard2025@cluster0.ira0ibj.mongodb.net/
+MONGO_URI=mongodb://localhost:27017/geargaurd
 NODE_ENV=development

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 PORT=5000
-MONGO_URI=mongodb://localhost:27017/geargaurd
+MONGO_URI=mongodb+srv://gearcard2025:gearcard2025@cluster0.ira0ibj.mongodb.net/
 NODE_ENV=development

--- a/client/src/components/RequestModal.tsx
+++ b/client/src/components/RequestModal.tsx
@@ -51,19 +51,22 @@ const RequestModal: React.FC<RequestModalProps> = ({
     loadData();
   }, []);
 
-  // Auto-fill team and technician when equipment is selected
-  useEffect(() => {
-    if (formData.equipmentId) {
-      const selectedEquipment = equipment.find((e) => e.id === formData.equipmentId);
-      if (selectedEquipment) {
-        setFormData((prev) => ({
-          ...prev,
-          teamId: selectedEquipment.maintenanceTeamId || prev.teamId,
-          assignedToId: selectedEquipment.defaultTechnicianId || prev.assignedToId,
-        }));
-      }
-    }
-  }, [formData.equipmentId, equipment]);
+ // Auto-fill team and technician when equipment is selected
+useEffect(() => {
+  if (!formData.equipmentId) return;
+
+  const selectedEquipment = equipment.find(
+    (e) => e._id.toString() === formData.equipmentId
+  );
+
+  if (!selectedEquipment) return;
+
+  setFormData((prev) => ({
+    ...prev,
+    teamId: selectedEquipment.maintenanceTeamId?.toString() || '',
+    assignedToId: selectedEquipment.defaultTechnicianId?.toString() || '',
+  }));
+}, [formData.equipmentId, equipment]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -159,7 +162,7 @@ const RequestModal: React.FC<RequestModalProps> = ({
           >
             <option value="">Select equipment...</option>
             {equipment.map((item) => (
-              <option key={item.id} value={item.id}>
+              <option key={item._id} value={item._id}>
                 {item.name} - {item.serialNumber}
               </option>
             ))}
@@ -177,7 +180,7 @@ const RequestModal: React.FC<RequestModalProps> = ({
           >
             <option value="">Select team...</option>
             {teams.map((team) => (
-              <option key={team.id} value={team.id}>
+              <option key={team._id} value={team._id}>
                 {team.name}
               </option>
             ))}
@@ -197,9 +200,8 @@ const RequestModal: React.FC<RequestModalProps> = ({
           >
             <option value="">Select technician...</option>
             {members
-              .filter((m) => !formData.teamId || m.teamId === formData.teamId)
               .map((member) => (
-                <option key={member.id} value={member.id}>
+                <option key={member._id} value={member._id.toString()}>
                   {member.name} {member.role && `(${member.role})`}
                 </option>
               ))}

--- a/server/controllers/equipmentController.js
+++ b/server/controllers/equipmentController.js
@@ -1,9 +1,6 @@
 const { Equipment, MaintenanceTeam, TeamMember, MaintenanceRequest } = require('../models');
 
-const mongoose = require('mongoose');
 
-console.log("DB HOST:", mongoose.connection.host);
-console.log("DB NAME:", mongoose.connection.name);
 // Get all equipment
 exports.getAllEquipment = async (req, res) => {
   try {

--- a/server/controllers/equipmentController.js
+++ b/server/controllers/equipmentController.js
@@ -1,5 +1,9 @@
 const { Equipment, MaintenanceTeam, TeamMember, MaintenanceRequest } = require('../models');
 
+const mongoose = require('mongoose');
+
+console.log("DB HOST:", mongoose.connection.host);
+console.log("DB NAME:", mongoose.connection.name);
 // Get all equipment
 exports.getAllEquipment = async (req, res) => {
   try {


### PR DESCRIPTION
Fixes #5

### Summary
Resolved technician autofill issue in maintenance request form.

### Root Cause
Members were filtered using a non-existent `teamId`, removing the selected technician from dropdown options.

### Fix
- Removed incorrect filtering
- Ensured proper ID matching

### Result
Technician now auto-populates and displays correctly.