### PR TITLE
[NSoC'26] Add CSV export for maintenance requests and equipment records

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -78,7 +78,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1302,7 +1301,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1495,7 +1493,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1653,8 +1650,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/date-arithmetic": {
       "version": "4.1.0",
@@ -2229,7 +2225,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2559,7 +2554,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2746,7 +2740,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2835,7 +2828,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3260,7 +3252,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3361,7 +3352,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/client/src/components/DetailedRequestsTable.tsx
+++ b/client/src/components/DetailedRequestsTable.tsx
@@ -1,12 +1,14 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Fragment } from 'react';
 import { MaintenanceRequest } from '../types';
 import { requestService } from '../services/requestService';
 import Badge from './Badge';
-import { 
-  Calendar, 
-  AlertCircle, 
-  Clock, 
-  User, 
+import Button from './Button';
+import Papa from 'papaparse';
+import {
+  Calendar,
+  AlertCircle,
+  Clock,
+  User,
   Package,
   FileText,
   Settings,
@@ -46,48 +48,100 @@ const DetailedRequestsTable = () => {
   };
 
   const sortedRequests = [...requests].sort((a, b) => {
-    let aValue: any = a[sortField as keyof MaintenanceRequest];
-    let bValue: any = b[sortField as keyof MaintenanceRequest];
+    const aValue: any = a[sortField as keyof MaintenanceRequest];
+    const bValue: any = b[sortField as keyof MaintenanceRequest];
 
     if (aValue === undefined) return 1;
     if (bValue === undefined) return -1;
 
-    if (typeof aValue === 'string') {
+    if (typeof aValue === 'string' && typeof bValue === 'string') {
       return sortDirection === 'asc'
         ? aValue.localeCompare(bValue)
         : bValue.localeCompare(aValue);
     }
 
-    return sortDirection === 'asc' ? aValue - bValue : bValue - aValue;
+    return sortDirection === 'asc'
+      ? (aValue ?? 0) - (bValue ?? 0)
+      : (bValue ?? 0) - (aValue ?? 0);
   });
+
+  const handleExport = () => {
+    if (!sortedRequests || sortedRequests.length === 0) return;
+
+    const exportData = sortedRequests.map((request) => ({
+      'Request Date': request.createdAt
+        ? new Date(request.createdAt).toLocaleDateString('en-GB')
+        : '',
+      'Request ID': request.requestNumber || '',
+      Subject: request.subject || '',
+      Priority: request.priority || '',
+      Stage: request.stage || '',
+      Equipment: request.equipment?.name || 'Unassigned',
+      'Assigned To': request.assignedTo?.name || 'Unassigned',
+      Type: request.type || '',
+      Description: request.description || '',
+      'Scheduled Date': request.scheduledDate
+        ? new Date(request.scheduledDate).toLocaleDateString('en-GB')
+        : '',
+      Team: request.team?.name || 'Unassigned',
+      Duration: request.duration ? `${request.duration} hrs` : '',
+      Cost: request.cost ?? '',
+      'Completed Date': request.completedDate
+        ? new Date(request.completedDate).toLocaleDateString('en-GB')
+        : '',
+      Notes: request.notes || '',
+    }));
+
+    const csv = Papa.unparse(exportData);
+
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', 'maintenance-requests.csv');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    URL.revokeObjectURL(url);
+  };
 
   const getPriorityColor = (priority: string) => {
     switch (priority) {
-      case 'urgent': return 'bg-red-100 text-red-700';
-      case 'high': return 'bg-orange-100 text-orange-700';
-      case 'medium': return 'bg-yellow-100 text-yellow-700';
-      case 'low': return 'bg-green-100 text-green-700';
-      default: return 'bg-gray-100 text-gray-700';
+      case 'urgent':
+        return 'bg-red-100 text-red-700';
+      case 'high':
+        return 'bg-orange-100 text-orange-700';
+      case 'medium':
+        return 'bg-yellow-100 text-yellow-700';
+      case 'low':
+        return 'bg-green-100 text-green-700';
+      default:
+        return 'bg-gray-100 text-gray-700';
     }
   };
 
   const getStageColor = (stage: string) => {
     switch (stage) {
-      case 'new': return 'bg-blue-100 text-blue-700';
-      case 'in-progress': return 'bg-yellow-100 text-yellow-700';
-      case 'repaired': return 'bg-green-100 text-green-700';
-      case 'scrap': return 'bg-red-100 text-red-700';
-      default: return 'bg-gray-100 text-gray-700';
+      case 'new':
+        return 'bg-blue-100 text-blue-700';
+      case 'in-progress':
+        return 'bg-yellow-100 text-yellow-700';
+      case 'repaired':
+        return 'bg-green-100 text-green-700';
+      case 'scrap':
+        return 'bg-red-100 text-red-700';
+      default:
+        return 'bg-gray-100 text-gray-700';
     }
   };
 
   const SortIcon = ({ field }: { field: string }) => {
     if (sortField !== field) return <Clock className="w-4 h-4 text-gray-400" />;
-    return sortDirection === 'asc' ? (
-      <ChevronUp className="w-4 h-4 text-blue-600" />
-    ) : (
-      <ChevronDown className="w-4 h-4 text-blue-600" />
-    );
+    return sortDirection === 'asc'
+      ? <ChevronUp className="w-4 h-4 text-blue-600" />
+      : <ChevronDown className="w-4 h-4 text-blue-600" />;
   };
 
   if (loading) {
@@ -96,7 +150,7 @@ const DetailedRequestsTable = () => {
         <div className="animate-pulse space-y-4">
           <div className="h-4 bg-gray-200 rounded w-1/4"></div>
           <div className="space-y-3">
-            {[1, 2, 3, 4].map(i => (
+            {[1, 2, 3, 4].map((i) => (
               <div key={i} className="h-12 bg-gray-200 rounded"></div>
             ))}
           </div>
@@ -107,9 +161,14 @@ const DetailedRequestsTable = () => {
 
   return (
     <div className="bg-white rounded-lg shadow">
-      <div className="border-b border-gray-200 px-6 py-4">
-        <h2 className="text-xl font-semibold text-gray-900">All Maintenance Requests</h2>
-        <p className="text-sm text-gray-500 mt-1">Detailed view of all requests with full information</p>
+      <div className="border-b border-gray-200 px-6 py-4 flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900">All Maintenance Requests</h2>
+          <p className="text-sm text-gray-500 mt-1">
+            Detailed view of all requests with full information
+          </p>
+        </div>
+        <Button onClick={handleExport}>Export CSV</Button>
       </div>
 
       <div className="overflow-x-auto">
@@ -172,11 +231,11 @@ const DetailedRequestsTable = () => {
               </th>
             </tr>
           </thead>
+
           <tbody className="bg-white divide-y divide-gray-200">
             {sortedRequests.map((request) => (
-              <>
+              <Fragment key={request.id}>
                 <tr
-                  key={request.id}
                   className="hover:bg-gray-50 transition-colors cursor-pointer"
                   onClick={() => setExpandedRow(expandedRow === request.id ? null : request.id)}
                 >
@@ -216,6 +275,7 @@ const DetailedRequestsTable = () => {
                     </button>
                   </td>
                 </tr>
+
                 {expandedRow === request.id && (
                   <tr className="bg-gray-50">
                     <td colSpan={8} className="px-6 py-4">
@@ -270,7 +330,7 @@ const DetailedRequestsTable = () => {
                     </td>
                   </tr>
                 )}
-              </>
+              </Fragment>
             ))}
           </tbody>
         </table>

--- a/client/src/pages/EquipmentList.tsx
+++ b/client/src/pages/EquipmentList.tsx
@@ -3,6 +3,7 @@ import { Equipment } from '../types';
 import { equipmentService } from '../services/equipmentService';
 import Badge from '../components/Badge';
 import Button from '../components/Button';
+import Papa from 'papaparse';
 import { Plus, Wrench, MapPin, Calendar } from 'lucide-react';
 import EquipmentModal from '../components/EquipmentModal';
 import EquipmentDetailModal from '../components/EquipmentDetailModal';
@@ -36,6 +37,36 @@ const EquipmentList: React.FC = () => {
     'under-maintenance': 'warning',
   } as const;
 
+  const handleExport = () => {
+    if (!equipment || equipment.length === 0) return;
+
+    const exportData = equipment.map((item) => ({
+      Name: item.name,
+      SerialNumber: item.serialNumber,
+      Location: item.location,
+      Department: item.department || '',
+      Status: item.status,
+      'Maintenance Team': item.maintenanceTeam?.name || '',
+      'Purchase Date': item.purchaseDate
+        ? new Date(item.purchaseDate).toLocaleDateString('en-GB')
+        : '',
+    }));
+
+    const csv = Papa.unparse(exportData);
+
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', 'equipment-records.csv');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    URL.revokeObjectURL(url);
+  };
+
   if (loading) {
     return <div className="text-center py-8">Loading equipment...</div>;
   }
@@ -47,81 +78,83 @@ const EquipmentList: React.FC = () => {
           <h2 className="text-2xl font-bold text-gray-900">Equipment Management</h2>
           <p className="text-gray-600 mt-1">Manage and monitor all equipment resources</p>
         </div>
-        <Button onClick={() => setIsModalOpen(true)}>
-          <Plus className="h-4 w-4 mr-2" />
-          Add Equipment
-        </Button>
+
+        <div className="flex gap-2">
+          <Button onClick={handleExport}>Export CSV</Button>
+
+          <Button onClick={() => setIsModalOpen(true)}>
+            <Plus className="h-4 w-4 mr-2" />
+            Add Equipment
+          </Button>
+        </div>
       </div>
 
-      {/* Resource Manager - Main View */}
       <ResourceManager />
 
-      {/* Equipment Grid - Card View */}
       <div>
         <h3 className="text-lg font-semibold text-gray-900 mb-4">All Equipment</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {equipment.map((item) => (
-          <div
-            key={item.id}
-            className="bg-white rounded-lg shadow hover:shadow-md transition-shadow p-6 cursor-pointer"
-            onClick={() => setSelectedEquipment(item)}
-          >
-            <div className="flex justify-between items-start mb-4">
-              <h3 className="font-semibold text-lg text-gray-900">{item.name}</h3>
-              <Badge variant={statusColors[item.status]}>
-                {item.status}
-              </Badge>
-            </div>
-
-            <div className="space-y-2 text-sm text-gray-600">
-              <div className="flex items-center">
-                <span className="font-medium mr-2">SN:</span>
-                {item.serialNumber}
-              </div>
-              
-              <div className="flex items-center">
-                <MapPin className="h-4 w-4 mr-2" />
-                {item.location}
+          {equipment.map((item) => (
+            <div
+              key={item.id}
+              className="bg-white rounded-lg shadow hover:shadow-md transition-shadow p-6 cursor-pointer"
+              onClick={() => setSelectedEquipment(item)}
+            >
+              <div className="flex justify-between items-start mb-4">
+                <h3 className="font-semibold text-lg text-gray-900">{item.name}</h3>
+                <Badge variant={statusColors[item.status]}>
+                  {item.status}
+                </Badge>
               </div>
 
-              {item.department && (
+              <div className="space-y-2 text-sm text-gray-600">
                 <div className="flex items-center">
-                  <span className="font-medium">Dept:</span>
-                  <span className="ml-2">{item.department}</span>
+                  <span className="font-medium mr-2">SN:</span>
+                  {item.serialNumber}
                 </div>
-              )}
 
-              {item.maintenanceTeam && (
-                <div className="text-xs text-gray-500">
-                  Team: {item.maintenanceTeam.name}
+                <div className="flex items-center">
+                  <MapPin className="h-4 w-4 mr-2" />
+                  {item.location}
                 </div>
-              )}
 
-              {item.purchaseDate && (
-                <div className="flex items-center text-xs text-gray-500">
-                  <Calendar className="h-3 w-3 mr-1" />
-                  Purchased: {new Date(item.purchaseDate).toLocaleDateString()}
-                </div>
-              )}
-            </div>
-
-            {/* Smart Button */}
-            <div className="mt-4 pt-4 border-t">
-              <button className="flex items-center justify-between w-full text-sm text-primary-600 hover:text-primary-700 font-medium">
-                <span className="flex items-center">
-                  <Wrench className="h-4 w-4 mr-2" />
-                  Maintenance
-                </span>
-                {item.openRequestsCount !== undefined && item.openRequestsCount > 0 && (
-                  <Badge variant="warning" size="sm">
-                    {item.openRequestsCount}
-                  </Badge>
+                {item.department && (
+                  <div className="flex items-center">
+                    <span className="font-medium">Dept:</span>
+                    <span className="ml-2">{item.department}</span>
+                  </div>
                 )}
-              </button>
+
+                {item.maintenanceTeam && (
+                  <div className="text-xs text-gray-500">
+                    Team: {item.maintenanceTeam.name}
+                  </div>
+                )}
+
+                {item.purchaseDate && (
+                  <div className="flex items-center text-xs text-gray-500">
+                    <Calendar className="h-3 w-3 mr-1" />
+                    Purchased: {new Date(item.purchaseDate).toLocaleDateString()}
+                  </div>
+                )}
+              </div>
+
+              <div className="mt-4 pt-4 border-t">
+                <button className="flex items-center justify-between w-full text-sm text-primary-600 hover:text-primary-700 font-medium">
+                  <span className="flex items-center">
+                    <Wrench className="h-4 w-4 mr-2" />
+                    Maintenance
+                  </span>
+                  {item.openRequestsCount !== undefined && item.openRequestsCount > 0 && (
+                    <Badge variant="warning" size="sm">
+                      {item.openRequestsCount}
+                    </Badge>
+                  )}
+                </button>
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
       </div>
 
       {equipment.length === 0 && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^4.18.2",
         "mongoose": "^7.8.8",
         "morgan": "^1.10.0",
+        "papaparse": "^5.5.3",
         "socket.io": "^4.8.3"
       },
       "devDependencies": {
@@ -23,9 +24,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -33,9 +34,9 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.4.tgz",
-      "integrity": "sha512-p7X/ytJDIdwUfFL/CLOhKgdfJe1Fa8uw9seJYvdOmnP9JBWGWHW69HkOixXS6Wy9yvGf1MbhcS6lVmrhy4jm2g==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.8.tgz",
+      "integrity": "sha512-kpjr2jy2w71w0oqAMI8oibBmiF9lXxWkEQs5gMkW4hVE48bsqINGLxnCSYW62ck/NHXJQpQEfA9WlJ1sY0eqBg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -58,12 +59,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
-      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/webidl-conversions": {
@@ -151,11 +152,14 @@
       "license": "MIT"
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/base64id": {
       "version": "2.0.0",
@@ -222,14 +226,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -382,13 +388,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/concurrently": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
@@ -454,9 +453,9 @@
       "license": "MIT"
     },
     "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -464,6 +463,10 @@
       },
       "engines": {
         "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/date-fns": {
@@ -881,9 +884,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1021,9 +1024,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1104,16 +1107,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mongodb": {
@@ -1168,9 +1174,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "7.8.8",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.8.tgz",
-      "integrity": "sha512-0ntQOglVjlx3d+1sLK45oO5f6GuTgV/zbao0zkpE5S5W40qefpyYQ3Mq9e9nRzR58pp57WkVU+PgM64sVVcxNg==",
+      "version": "7.8.9",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.9.tgz",
+      "integrity": "sha512-V3GBAJbmOAdzEP8murOvlg7q1szlbe4jTBRyW+JBHRduJBe7F9dk5eyqJDTuYrdBcOOWfLbr6AgXrDK7F0/o5A==",
       "license": "MIT",
       "dependencies": {
         "bson": "^5.5.0",
@@ -1283,16 +1289,16 @@
       }
     },
     "node_modules/nodemon": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.11.tgz",
-      "integrity": "sha512-is96t8F/1//UHAjNPHpbsNY46ELPpftGUoSVNXwUfMk/qdjSylYrWSu1XavVTBOn526kFiOR733ATgNBCQyH0g==",
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
         "debug": "^4",
         "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.1",
         "pstree.remy": "^1.1.8",
         "semver": "^7.5.3",
         "simple-update-notifier": "^2.0.0",
@@ -1411,6 +1417,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1421,15 +1433,15 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1469,9 +1481,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1567,9 +1579,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1663,13 +1675,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2019,9 +2031,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express": "^4.18.2",
     "mongoose": "^7.8.8",
     "morgan": "^1.10.0",
+    "papaparse": "^5.5.3",
     "socket.io": "^4.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds a CSV export feature for both the Equipment page and the Maintenance Requests page.

Users can now download the currently visible data as a CSV file, which makes it easier to share and work with in tools like Excel.

What I implemented:
- Added an "Export CSV" button on both pages
- Exported only the visible (sorted) data
- Used clear and readable column names
- Formatted dates properly (DD/MM/YYYY)

The feature is implemented on the frontend using papaparse, without requiring any backend changes.

This improves usability by allowing users to quickly generate reports and export data when needed.