### PR TITLE
fix: replace Settings nav item with compact icon button

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { NavLink } from 'react-router-dom';
+import React, { useState, useRef, useEffect } from 'react';
+import { NavLink, useNavigate } from 'react-router-dom';
 import { Wrench, Box, Users, Calendar, LayoutDashboard, List, Activity, Bell, Menu, X, Car, Settings, Shield } from 'lucide-react';
 import NotificationCenter from './NotificationCenter';
 
@@ -9,6 +9,19 @@ interface LayoutProps {
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const settingsRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (settingsRef.current && !settingsRef.current.contains(e.target as Node)) {
+        setSettingsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
 
   const navItems = [
     { to: '/', icon: LayoutDashboard, label: 'Dashboard', gradient: 'from-blue-500 to-purple-600' },
@@ -20,7 +33,6 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     { to: '/vehicles', icon: Car, label: 'Vehicles', gradient: 'from-orange-500 to-red-600' },
     { to: '/teams', icon: Users, label: 'Teams', gradient: 'from-yellow-500 to-orange-600' },
     { to: '/activity', icon: Activity, label: 'Activity', gradient: 'from-indigo-500 to-purple-600' },
-    { to: '/settings', icon: Settings, label: 'Settings', gradient: 'from-gray-500 to-slate-700' },
   ];
 
   return (
@@ -77,7 +89,44 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
             {/* Actions */}
             <div className="flex items-center space-x-2 lg:space-x-3">
               <NotificationCenter />
-              
+
+              {/* Settings Icon with Dropdown */}
+              <div className="relative" ref={settingsRef}>
+                <button
+                  onClick={() => setSettingsOpen(!settingsOpen)}
+                  title="Settings"
+                  className={`rounded-xl border p-2 shadow-sm backdrop-blur-xl transition-all duration-200 ${
+                    settingsOpen
+                      ? 'border-purple-300 bg-gradient-to-r from-blue-600 to-purple-600 text-white'
+                      : 'border-white/50 bg-white/30 text-gray-600 hover:border-white/70 hover:text-purple-600'
+                  }`}
+                >
+                  <Settings className={`h-5 w-5 transition-transform duration-300 ${settingsOpen ? 'rotate-90' : ''}`} />
+                </button>
+
+                {settingsOpen && (
+                  <div className="absolute right-0 mt-2 w-48 rounded-2xl border border-white/50 bg-white/90 shadow-xl backdrop-blur-xl z-50 overflow-hidden">
+                    <div className="px-4 py-2.5 border-b border-gray-100">
+                      <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Settings</p>
+                    </div>
+                    <button
+                      onClick={() => { navigate('/settings'); setSettingsOpen(false); }}
+                      className="flex w-full items-center gap-3 px-4 py-3 text-sm text-gray-700 hover:bg-purple-50 hover:text-purple-700 transition-colors"
+                    >
+                      <Settings className="h-4 w-4" />
+                      App Settings
+                    </button>
+                    <button
+                      onClick={() => { navigate('/profile'); setSettingsOpen(false); }}
+                      className="flex w-full items-center gap-3 px-4 py-3 text-sm text-gray-700 hover:bg-purple-50 hover:text-purple-700 transition-colors"
+                    >
+                      <Users className="h-4 w-4" />
+                      Profile
+                    </button>
+                  </div>
+                )}
+              </div>
+
               {/* User Avatar */}
               <div className="hidden lg:flex items-center space-x-3">
                 <div className="w-9 h-9 rounded-xl border border-white/50 bg-gradient-to-r from-blue-600 to-purple-600 flex items-center justify-center text-white text-sm font-semibold shadow-lg ring-1 ring-white/40">


### PR DESCRIPTION
Fixes #86

## Problem
The navbar had a full Settings nav item in the center navigation bar alongside 9 other items, making it look cluttered and taking up unnecessary space.

## Solution
Removed the Settings nav item from the center nav bar and replaced it with a compact gear icon button in the right actions area (next to the notification bell and user avatar).

## Changes (Layout.tsx only)
- Removed Settings from navItems to declutter the center nav
- Added compact Settings icon button in the right actions area
- Icon rotates 90deg when dropdown is open for visual feedback
- Dropdown with App Settings and Profile quick-links opens on click
- Click-outside listener auto-closes the dropdown
- Styled consistently with the existing glassmorphism design

## Before vs After
Before: 10 nav items crammed in the center nav bar including a full Settings link
After: 9 nav items in center nav + compact settings icon with dropdown on the right

## Testing
1. Open the app
2. Verify Settings is no longer in the center nav bar
3. Click the gear icon on the top right
4. Dropdown should open with App Settings and Profile options
5. Click outside the dropdown - it should close automatically
<img width="1907" height="1022" alt="image" src="https://github.com/user-attachments/assets/c4f2a861-63b7-4e58-9ab2-d75088079a0a" />
