### PR TITLE
Security: Restrict role assignment during user registration (NSoC'26)

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -5,7 +5,7 @@ const jwt = require("jsonwebtoken");
 /// REGISTER
 exports.register = async (req, res) => {
   try {
-    const { name, email, password, role } = req.body;
+    const { name, email, password } = req.body;
 
     // Check existing user
     const existingUser = await User.findOne({ email });
@@ -20,8 +20,7 @@ exports.register = async (req, res) => {
     const user = await User.create({
       name,
       email,
-      password: hashedPassword,
-      role
+      password: hashedPassword
     });
 
     // 🔥 Remove password before sending response


### PR DESCRIPTION
### Problem
A security vulnerability existed where the user registration flow accepted the `role` field directly from the client request body without server-side validation. This allowed any user to register as an `Admin` or `Manager` simply by modifying the registration request.

### Solution
Modified `server/controllers/authController.js` to:
- Remove `role` from the request body destructuring in the `register` function.
- - Ensure the `role` field is not passed to the `User.create()` call.
- - This forces the system to use the server-side default role (`Technician`) for all new registrations.
### Verification
- Verified through manual code inspection.
- - Verified using a simulation script that attempts registration with `role: "Admin"` and confirms it is ignored by the server.
Participating in **NSoC'26**.