### PR TITLE
fix: resolve infinite XP/inventory exploit and gamification crashes

### DIFF
--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -284,7 +284,7 @@ const request = await MaintenanceRequest.create({
 };
 
 // --- GAMIFICATION LOGIC ---
-const processGamification = async (request, prevStage, newStage) => {
+const processGamification = async (request, prevStage, newStage, shouldProcessCompletion) => {
   if (!request.assignedToId && !request.assignedTo) return;
 
   const memberId = request.assignedToId || request.assignedTo._id;
@@ -295,9 +295,10 @@ const processGamification = async (request, prevStage, newStage) => {
 
   let pointsToAdd = 0;
   const newBadges = [];
+  const userBadges = member.badges || [];
 
   // Check First Responder (moved from new -> in-progress)
-  if (prevStage === 'new' && newStage === 'in-progress' && request.priority === 'urgent' && !member.badges.includes('First Responder')) {
+  if (prevStage === 'new' && newStage === 'in-progress' && request.priority === 'urgent' && !userBadges.includes('First Responder')) {
     const diffMins = (new Date() - new Date(request.createdAt)) / 1000 / 60;
     if (diffMins <= 5) {
       newBadges.push('First Responder');
@@ -306,10 +307,7 @@ const processGamification = async (request, prevStage, newStage) => {
   }
 
   // Check points for completion
-  const isCompleted = prevStage === 'repaired' || prevStage === 'scrap';
-  const nowCompleted = newStage === 'repaired' || newStage === 'scrap';
-  
-  if (nowCompleted && !isCompleted) {
+  if (shouldProcessCompletion) {
     const basePoints = 10;
     let multiplier = 1;
     if (request.priority === 'medium') multiplier = 1.5;
@@ -319,7 +317,7 @@ const processGamification = async (request, prevStage, newStage) => {
     pointsToAdd += Math.floor(basePoints * multiplier);
 
     // Check Master Mechanic badge
-    if (!member.badges.includes('Master Mechanic')) {
+    if (!userBadges.includes('Master Mechanic')) {
       const completedCount = await MaintenanceRequest.countDocuments({
         $or: [ { assignedToId: member._id }, { assignedTo: member._id } ],
         stage: { $in: ['repaired', 'scrap'] }
@@ -415,7 +413,8 @@ exports.updateRequest = async (req, res) => {
 
     const isCompleted = prevStage === "repaired" || prevStage === "scrap";
     const nowCompleted = payload.stage === "repaired" || payload.stage === "scrap";
-    if (payload.stage && nowCompleted && !isCompleted) {
+    const shouldProcessCompletion = payload.stage && nowCompleted && !isCompleted && !request.completionProcessed;
+    if (shouldProcessCompletion) {
       const io = req.app.get("socketio");
       await decrementInventory(io, request.partsUsed);
     }
@@ -485,7 +484,11 @@ exports.updateRequest = async (req, res) => {
       });
     }
 
-    await processGamification(updatedRequest, prevStage, payload.stage || updatedRequest.stage);
+    await processGamification(updatedRequest, prevStage, payload.stage || updatedRequest.stage, shouldProcessCompletion);
+
+    if (shouldProcessCompletion) {
+      await MaintenanceRequest.findByIdAndUpdate(req.params.id, { completionProcessed: true });
+    }
 
     res.json(updatedRequest);
   } catch (error) {
@@ -532,7 +535,8 @@ exports.updateRequestStage = async (req, res) => {
 
     const isCompleted = prevStage === "repaired" || prevStage === "scrap";
     const nowCompleted = stage === "repaired" || stage === "scrap";
-    if (nowCompleted && !isCompleted) {
+    const shouldProcessCompletion = nowCompleted && !isCompleted && !request.completionProcessed;
+    if (shouldProcessCompletion) {
       const io = req.app.get("socketio");
       await decrementInventory(io, request.partsUsed);
     }
@@ -595,7 +599,11 @@ exports.updateRequestStage = async (req, res) => {
       });
     }
 
-    await processGamification(updatedRequest, prevStage, stage);
+    await processGamification(updatedRequest, prevStage, stage, shouldProcessCompletion);
+
+    if (shouldProcessCompletion) {
+      await MaintenanceRequest.findByIdAndUpdate(req.params.id, { completionProcessed: true });
+    }
 
     res.json(updatedRequest);
   } catch (error) {

--- a/server/models/MaintenanceRequest.js
+++ b/server/models/MaintenanceRequest.js
@@ -17,6 +17,10 @@ const MaintenanceRequestSchema = new Schema({
     type: Boolean,
     default: false,
   },
+  completionProcessed: {
+    type: Boolean,
+    default: false,
+  },
   attachments: [
   {
     filename: { type: String },


### PR DESCRIPTION
## Title: fix: Resolve critical infinite XP/inventory exploit and gamification crashes

Closes #137 

### 📝 Description
This Pull Request addresses several critical bugs introduced in the gamification system that completely invalidated the feature's logic and posed a severe risk to application stability and data integrity.

### 🐛 Issues Fixed
- **Infinite Gamification XP Exploit:** Fixed a logic flaw where moving a task back and forth between "In Progress" and "Repaired" repeatedly awarded points to the technician without ever deducting them.
- **Infinite Spare Parts Depletion:** The same toggle exploit was found to repeatedly trigger `decrementInventory`, pushing spare part quantities into the negatives.
- **Server Crash (Unhandled TypeError):** Legacy `TeamMember` documents that lacked a populated `badges` array in the database would cause a `TypeError: Cannot read properties of undefined (reading 'includes')`, crashing the server during Kanban drag-and-drop operations.

### 🛠️ Implementation Details
- **`MaintenanceRequest` Schema:** Added a `completionProcessed` boolean flag defaulting to `false` to track if the end-of-lifecycle logic (points awarded & inventory decremented) has already been executed for a specific request.
- **`requestController.js` (Gamification & Inventory logic):** 
  - Restructured `updateRequest` and `updateRequestStage` to check the `!request.completionProcessed` flag before triggering inventory or gamification processes.
  - The flag is immediately flipped to `true` upon execution to permanently lock the request from future duplicate processing.
  - Safely coalesced `badges` arrays in `processGamification` (`const userBadges = member.badges || []`) to safeguard against `undefined` exceptions on legacy profiles.

### ✅ Checklist
- [x] XP Farming exploit closed.
- [x] Inventory Depletion exploit closed.
- [x] Legacy user exception handling added.
- [x] Unit tests passing successfully (`npm test`).
