### PR TITLE
feat: implement downtime financial impact engine (fixes #148)

### DIFF
--- a/client/src/components/EquipmentModal.tsx
+++ b/client/src/components/EquipmentModal.tsx
@@ -97,6 +97,7 @@ const EquipmentModal: React.FC<EquipmentModalProps> = ({
         purchaseDate: formData.purchaseDate || undefined,
         warrantyExpiry: formData.warrantyExpiry || undefined,
         notes: formData.notes?.trim() || undefined,
+        hourlyDowntimeCost: formData.hourlyDowntimeCost || 0,
       };
 
       await equipmentService.create(payload);
@@ -391,6 +392,23 @@ const EquipmentModal: React.FC<EquipmentModalProps> = ({
                 </option>
               ))}
           </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+            Hourly Downtime Cost ($)
+          </label>
+          <input
+            type="number"
+            min="0"
+            step="0.01"
+            value={formData.hourlyDowntimeCost || ""}
+            onChange={(e) =>
+              setFormData({ ...formData, hourlyDowntimeCost: Number(e.target.value) })
+            }
+            className="input-dark"
+            placeholder="e.g. 150"
+          />
         </div>
 
         <div>

--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -102,6 +102,11 @@ const AnalyticsPage: React.FC = () => {
     [data]
   );
 
+  const costByCategoryData = useMemo(
+    () => data?.charts.costByCategory || [],
+    [data]
+  );
+
   if (loading) {
     return <Spinner size="lg" label="Loading analytics..." centered />;
   }
@@ -168,7 +173,7 @@ const AnalyticsPage: React.FC = () => {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
         <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
           <p className="text-sm text-gray-500 dark:text-gray-400">Total requests</p>
           <p className="mt-2 text-3xl font-bold text-gray-900 dark:text-white">
@@ -185,6 +190,14 @@ const AnalyticsPage: React.FC = () => {
           <p className="text-sm text-gray-500 dark:text-gray-400">Overdue rate</p>
           <p className="mt-2 text-3xl font-bold text-gray-900 dark:text-white">
             {data?.metrics.overdueRate ?? 0}%
+          </p>
+        </div>
+        <div className="rounded-xl border border-red-200 bg-red-50 p-5 shadow-sm dark:border-red-900/50 dark:bg-red-900/10">
+          <p className="text-sm font-semibold text-red-600 dark:text-red-400 flex items-center">
+            <span className="mr-1">💸</span> Financial Bleed
+          </p>
+          <p className="mt-2 text-3xl font-bold text-red-700 dark:text-red-300">
+            ${data?.metrics.totalFinancialLoss?.toLocaleString() || '0'}
           </p>
         </div>
       </div>
@@ -227,26 +240,45 @@ const AnalyticsPage: React.FC = () => {
         </div>
       </div>
 
-      <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-        <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Request trend</h3>
-        <div className="h-80">
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={trendChartData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="label" />
-              <YAxis allowDecimals={false} />
-              <Tooltip />
-              <Legend />
-              <Line type="monotone" dataKey="total" stroke="#3B82F6" strokeWidth={2} dot={false} />
-              <Line
-                type="monotone"
-                dataKey="completed"
-                stroke="#10B981"
-                strokeWidth={2}
-                dot={false}
-              />
-            </LineChart>
-          </ResponsiveContainer>
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-2 mt-6">
+        <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Request trend</h3>
+          <div className="h-80">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={trendChartData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="label" />
+                <YAxis allowDecimals={false} />
+                <Tooltip />
+                <Legend />
+                <Line type="monotone" dataKey="total" stroke="#3B82F6" strokeWidth={2} dot={false} />
+                <Line
+                  type="monotone"
+                  dataKey="completed"
+                  stroke="#10B981"
+                  strokeWidth={2}
+                  dot={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-red-100 bg-white p-5 shadow-sm dark:border-red-900/30 dark:bg-gray-800">
+          <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white flex items-center">
+            <span className="mr-2">📉</span> Cost by Category
+          </h3>
+          <div className="h-80">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={costByCategoryData} layout="vertical" margin={{ left: 20 }}>
+                <CartesianGrid strokeDasharray="3 3" horizontal={false} />
+                <XAxis type="number" tickFormatter={(val) => `$${val}`} />
+                <YAxis type="category" dataKey="category" width={80} />
+                <Tooltip formatter={(value: number) => [`$${value}`, 'Lost Revenue']} />
+                <Bar dataKey="value" fill="#ef4444" radius={[0, 4, 4, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
         </div>
       </div>
     </div>

--- a/client/src/pages/EquipmentList.tsx
+++ b/client/src/pages/EquipmentList.tsx
@@ -264,6 +264,13 @@ const EquipmentList: React.FC = () => {
                       }
                     </div>
 
+                    {item.hourlyDowntimeCost !== undefined && item.hourlyDowntimeCost > 0 && (
+                      <div className="flex items-center text-red-500 font-medium">
+                        <span className="mr-2">💸</span>
+                        Downtime: ${item.hourlyDowntimeCost}/hr
+                      </div>
+                    )}
+
                     {item.department && (
                       <div className="flex items-center">
                         <span className="font-medium">

--- a/client/src/pages/KanbanBoard.tsx
+++ b/client/src/pages/KanbanBoard.tsx
@@ -31,6 +31,7 @@ import {
   AlertCircle,
   Plus,
   Sparkles,
+  ArrowDownUp
 } from "lucide-react";
 
 import toast from "react-hot-toast";
@@ -255,6 +256,12 @@ const RequestCard: React.FC<
         </div>
       )}
 
+      {request.equipment?.hourlyDowntimeCost ? (
+        <div className="text-xs text-red-500 font-bold mt-2 flex items-center bg-red-50 dark:bg-red-900/20 px-2 py-1 rounded w-fit border border-red-100 dark:border-red-800/50 shadow-sm">
+          💸 Bleed: ${request.equipment.hourlyDowntimeCost}/hr
+        </div>
+      ) : null}
+
       {!request.assignedTo && (
         <button
           onClick={handleSmartAssign}
@@ -281,6 +288,8 @@ interface ColumnProps {
   onUpdate: () => void;
 
   onRequestClick: (requestId: string) => void;
+  
+  sortByCost: boolean;
 }
 
 const Column: React.FC<
@@ -290,6 +299,7 @@ const Column: React.FC<
   requests,
   onDrop,
   onRequestClick,
+  sortByCost
 }) => {
   const [{ isOver }, drop] =
     useDrop(() => ({
@@ -345,7 +355,12 @@ const Column: React.FC<
           </p>
         )}
 
-        {requests.map(
+        {[...requests].sort((a, b) => {
+          if (!sortByCost) return 0;
+          const costA = a.equipment?.hourlyDowntimeCost || 0;
+          const costB = b.equipment?.hourlyDowntimeCost || 0;
+          return costB - costA;
+        }).map(
           (request) => (
             <RequestCard
               key={request.id}
@@ -388,6 +403,8 @@ const KanbanBoard: React.FC =
       resultCount,
       setResultCount,
     ] = useState(0);
+
+    const [sortByCost, setSortByCost] = useState(false);
 
     useEffect(() => {
       loadRequests();
@@ -539,6 +556,13 @@ const KanbanBoard: React.FC =
                 variant="excel"
               />
               <Button
+                onClick={() => setSortByCost(!sortByCost)}
+                variant={sortByCost ? "primary" : "secondary"}
+              >
+                <ArrowDownUp className="h-4 w-4 mr-2" />
+                Sort by Cost Rate
+              </Button>
+              <Button
                 className="w-full sm:w-auto"
                 onClick={() => {
                   setEditRequestId(undefined);
@@ -596,6 +620,7 @@ const KanbanBoard: React.FC =
                       setEditRequestId(id);
                       setIsModalOpen(true);
                     }}
+                    sortByCost={sortByCost}
                   />
                 )
               )}

--- a/client/src/services/requestService.ts
+++ b/client/src/services/requestService.ts
@@ -19,11 +19,13 @@ export interface AnalyticsResponse {
     completedRequests: number;
     mttrHours: number;
     overdueRate: number;
+    totalFinancialLoss?: number;
   };
   charts: {
     stageBreakdown: Array<{ stage: string; value: number }>;
     typeBreakdown: Array<{ type: string; value: number }>;
     trend: Array<{ date: string; total: number; completed: number }>;
+    costByCategory?: Array<{ category: string; value: number }>;
   };
 }
 

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -26,6 +26,7 @@ export interface Equipment {
   defaultTechnician?: TeamMember;
   openRequestsCount?: number;
   mapCoordinates?: { x: number; y: number };
+  hourlyDowntimeCost?: number;
   createdAt?: string;
   updatedAt?: string;
 }
@@ -89,8 +90,11 @@ export interface MaintenanceRequest {
     content?: string;
     audioUrl?: string;
     audioDuration?: number;
+    audioDuration?: number;
     timestamp: string;
   }[];
+  downtimeDurationHours?: number;
+  totalDowntimeCost?: number;
   createdAt?: string;
   updatedAt?: string;
 }
@@ -114,6 +118,7 @@ export interface CreateEquipmentDto {
   maintenanceTeamId?: string;
   defaultTechnicianId?: string;
   mapCoordinates?: { x: number; y: number };
+  hourlyDowntimeCost?: number;
 }
 
 export interface CreateMaintenanceRequestDto {

--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -522,9 +522,24 @@ exports.updateRequestStage = async (req, res) => {
     await MaintenanceRequest.findByIdAndUpdate(req.params.id, { stage });
 
     if (stage === "repaired" || stage === "scrap") {
+      const completedDate = new Date();
+      let downtimeDurationHours = 0;
+      let totalDowntimeCost = 0;
+
+      if (request.createdAt) {
+        downtimeDurationHours = Math.max(0, (completedDate - request.createdAt) / (1000 * 60 * 60));
+      }
+
+      if (request.equipment && request.equipment.hourlyDowntimeCost) {
+        totalDowntimeCost = downtimeDurationHours * request.equipment.hourlyDowntimeCost;
+      }
+
       await MaintenanceRequest.findByIdAndUpdate(req.params.id, {
-        completedDate: new Date(),
+        completedDate,
+        downtimeDurationHours,
+        totalDowntimeCost
       });
+
       if (request.equipmentId) {
         const newStatus = stage === "scrap" ? "scrapped" : "active";
         await Equipment.findByIdAndUpdate(request.equipmentId, {
@@ -717,6 +732,8 @@ exports.getAnalytics = async (req, res) => {
       typeBreakdown,
       trendData,
       mttrResult,
+      financialLossResult,
+      costByCategory
     ] = await Promise.all([
       MaintenanceRequest.countDocuments(rangeMatch),
       MaintenanceRequest.countDocuments({
@@ -778,11 +795,41 @@ exports.getAnalytics = async (req, res) => {
           },
         },
       ]),
+      MaintenanceRequest.aggregate([
+        { $match: rangeMatch },
+        {
+          $group: {
+            _id: null,
+            totalCost: { $sum: "$totalDowntimeCost" },
+          },
+        },
+      ]),
+      MaintenanceRequest.aggregate([
+        { $match: rangeMatch },
+        {
+          $lookup: {
+            from: "equipments",
+            localField: "equipmentId",
+            foreignField: "_id",
+            as: "equipmentDoc"
+          }
+        },
+        { $unwind: "$equipmentDoc" },
+        {
+          $group: {
+            _id: "$equipmentDoc.category",
+            value: { $sum: "$totalDowntimeCost" }
+          }
+        },
+        { $project: { _id: 0, category: "$_id", value: 1 } },
+        { $sort: { value: -1 } }
+      ])
     ]);
 
     const avgResolutionMs = mttrResult[0]?.avgResolutionMs || 0;
     const mttrHours = avgResolutionMs ? avgResolutionMs / (1000 * 60 * 60) : 0;
     const overdueRate = totalRequests ? (overdueRequests / totalRequests) * 100 : 0;
+    const totalFinancialLoss = financialLossResult[0]?.totalCost || 0;
 
     res.json({
       range: {
@@ -795,11 +842,13 @@ exports.getAnalytics = async (req, res) => {
         completedRequests,
         mttrHours: Number(mttrHours.toFixed(2)),
         overdueRate: Number(overdueRate.toFixed(2)),
+        totalFinancialLoss: Number(totalFinancialLoss.toFixed(2)),
       },
       charts: {
         stageBreakdown,
         typeBreakdown,
         trend: trendData,
+        costByCategory
       },
     });
   } catch (error) {

--- a/server/models/Equipment.js
+++ b/server/models/Equipment.js
@@ -56,6 +56,10 @@ const EquipmentSchema = new Schema({
     maxHours: { type: Number, default: 2000 },
     maxTemp: { type: Number, default: 85 },
     maxVibration: { type: Number, default: 4.5 }
+  },
+  hourlyDowntimeCost: {
+    type: Number,
+    default: 0
   }
 }, { timestamps: true });
 

--- a/server/models/MaintenanceRequest.js
+++ b/server/models/MaintenanceRequest.js
@@ -43,7 +43,9 @@ const MaintenanceRequestSchema = new Schema({
     audioUrl: { type: String },
     audioDuration: { type: Number },
     timestamp: { type: Date, default: Date.now }
-  }]
+  }],
+  downtimeDurationHours: { type: Number, default: 0 },
+  totalDowntimeCost: { type: Number, default: 0 }
 }, { timestamps: true });
 
 MaintenanceRequestSchema.virtual('equipment', {

--- a/server/scripts/testDowntimeCost.js
+++ b/server/scripts/testDowntimeCost.js
@@ -1,0 +1,48 @@
+const { mongoose } = require('../config/database');
+const { MaintenanceRequest, Equipment, TeamMember } = require('../models');
+require('dotenv').config({ path: __dirname + '/../../.env' });
+
+async function seedDowntimeTest() {
+  try {
+    console.log('Connecting to DB...');
+    await mongoose.connect(process.env.MONGO_URI || 'mongodb://localhost:27017/gearguard');
+    console.log('Connected.');
+
+    // 1. Create a machine with a high hourly cost
+    console.log('Creating high-value equipment...');
+    const equipment = await Equipment.create({
+      name: 'Industrial CNC Router',
+      serialNumber: `CNC-${Date.now()}`,
+      category: 'Machine',
+      location: 'Factory Floor A',
+      status: 'active',
+      hourlyDowntimeCost: 500 // $500 an hour
+    });
+
+    const user = await TeamMember.findOne({});
+
+    // 2. Create a request and backdate its creation to 48 hours ago
+    console.log('Creating ticket backdated by 48 hours...');
+    const pastDate = new Date(Date.now() - (48 * 60 * 60 * 1000));
+    
+    const request = await MaintenanceRequest.create({
+      requestNumber: `REQ-DT-${Date.now()}`,
+      subject: 'Spindle motor failure',
+      description: 'The main spindle motor burnt out.',
+      stage: 'in-progress',
+      equipmentId: equipment._id,
+      createdById: user ? user._id : undefined,
+      createdAt: pastDate
+    });
+
+    console.log(`Created Request ID: ${request._id}`);
+    console.log('Use the UI to drag this ticket to "Repaired" and check the Analytics Dashboard to see $24,000 in Financial Bleed!');
+
+    process.exit(0);
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+seedDowntimeTest();


### PR DESCRIPTION
## 📌 Pull Request Title

implement downtime financial impact engine (fixes #148)

---

## 🚀 Description

This PR introduces the Downtime Financial Impact Engine, transforming GearGuard from a simple task tracker into a high-level financial analytics tool. Management can now visualize exactly how much revenue is lost to machine downtime and prioritize their team's efforts accordingly.

---

## 🔗 Related Issue

Closes #148 

---

## 📝 Changes Made

- [x] Schema Updates: Extended Equipment with hourlyDowntimeCost and MaintenanceRequest with downtimeDurationHours and totalDowntimeCost.
- [x] Automated Calculation Logic: Modified updateRequestStage in requestController.js. When a ticket is dragged to repaired, the backend calculates the hours elapsed since ticket creation, multiplies it by the hourly cost rate, and saves the financial bleed.
- [x] Kanban Upgrades:
- Added a 💸 Bleed: $X/hr badge on high-value equipment tickets.
- Added a "Sort by Cost Rate" toggle to reorder the Kanban columns by financial impact.
- [x] Analytics Dashboard:
- Added a glowing red "Financial Bleed" KPI card aggregating total lost revenue.
- Added a Recharts BarChart visualizing downtime cost distributed by Equipment Category.

---
## UI
<img width="374" height="157" alt="Screenshot 2026-05-28 at 10 57 28" src="https://github.com/user-attachments/assets/077e1d88-7661-49bf-8777-6e168f6974c0" />
<img width="298" height="233" alt="Screenshot 2026-05-28 at 10 57 36" src="https://github.com/user-attachments/assets/79d996f7-0721-4457-b82a-0334c618401a" />
<img width="567" height="459" alt="Screenshot 2026-05-28 at 11 00 31" src="https://github.com/user-attachments/assets/22bbb497-8512-4c86-b8e5-1c5feedf3030" />

## 🧪 Testing Performed

- [x] Tested locally
- [x] Templates render correctly on GitHub

---

## 🏷️ NSoC'26 Information

- **Level:** Level 3
- **Points:** 10

---

## ✅ Checklist

- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] This PR does not break existing functionality
- [x] I have added necessary documentation

---

## ⚠️ Important

- PR without issue assignment will be **rejected**
- Missing `NSoC'26` tag will be **requested for update**

---

Thank you for your contribution! 🎉