### PR TITLE
feat: implement health score tooltips and pulse animation (#152)

### DIFF
--- a/client/src/components/EquipmentDetailModal.tsx
+++ b/client/src/components/EquipmentDetailModal.tsx
@@ -63,7 +63,7 @@ const EquipmentDetailModal: React.FC<EquipmentDetailModalProps> = ({
         {/* Equipment Details */}
         <div className="grid grid-cols-2 gap-4">
           <div className="flex flex-col items-center justify-center p-4 bg-slate-50 dark:bg-slate-800/50 rounded-xl border border-slate-100 dark:border-slate-700/50">
-            <HealthRing score={equipment.healthScore ?? 100} size={80} strokeWidth={6} />
+            <HealthRing score={equipment.healthScore ?? 100} size={80} strokeWidth={6} breakdown={equipment.healthScoreBreakdown} />
             <div className="mt-3 flex flex-col items-center">
               <p className="text-xs text-gray-500 dark:text-gray-400 mb-1 tracking-wider uppercase">System Status</p>
               <Badge variant={statusColors[equipment.status]}>{equipment.status}</Badge>

--- a/client/src/components/HealthRing.tsx
+++ b/client/src/components/HealthRing.tsx
@@ -5,6 +5,7 @@ interface HealthRingProps {
   size?: number;
   strokeWidth?: number;
   showText?: boolean;
+  breakdown?: { factor: string; deduction: number }[];
 }
 
 const HealthRing: React.FC<HealthRingProps> = ({
@@ -12,6 +13,7 @@ const HealthRing: React.FC<HealthRingProps> = ({
   size = 60,
   strokeWidth = 6,
   showText = true,
+  breakdown,
 }) => {
   // Clamp score between 0 and 100
   const normalizedScore = Math.min(100, Math.max(0, score));
@@ -49,8 +51,8 @@ const HealthRing: React.FC<HealthRingProps> = ({
   const strokeDashoffset = circumference - (normalizedScore / 100) * circumference;
 
   return (
-    <div className="relative inline-flex items-center justify-center" style={{ width: size, height: size }}>
-      <svg className="transform -rotate-90 w-full h-full" viewBox={`0 0 ${size} ${size}`}>
+    <div className="relative inline-flex items-center justify-center group" style={{ width: size, height: size }}>
+      <svg className={`transform -rotate-90 w-full h-full ${normalizedScore < 40 ? 'animate-critical-pulse' : ''}`} viewBox={`0 0 ${size} ${size}`}>
         <defs>
           <linearGradient id={`gradient-${normalizedScore}`} x1="0%" y1="0%" x2="100%" y2="100%">
             <stop offset="0%" stopColor={colorObj.gradientStart} />
@@ -86,13 +88,29 @@ const HealthRing: React.FC<HealthRingProps> = ({
 
       {/* Center Text */}
       {showText && (
-        <div className="absolute flex flex-col items-center justify-center font-bold">
+        <div className="absolute flex flex-col items-center justify-center font-bold pointer-events-none">
           <span className={`text-lg leading-none ${colorObj.textClass}`}>
             {normalizedScore}
           </span>
           <span className={`text-[9px] uppercase tracking-wider ${colorObj.textClass} opacity-80 mt-0.5`}>
             Health
           </span>
+        </div>
+      )}
+
+      {/* Breakdown Tooltip */}
+      {breakdown && breakdown.length > 0 && (
+        <div className="absolute z-50 invisible group-hover:visible opacity-0 group-hover:opacity-100 transition-all duration-200 bottom-full mb-2 bg-gray-900 text-white text-xs rounded shadow-lg p-3 w-max min-w-[150px] max-w-[250px] text-center pointer-events-none">
+          <p className="font-semibold border-b border-gray-700 pb-1 mb-2">Score Deductions</p>
+          <ul className="text-left space-y-1">
+            {breakdown.map((item, i) => (
+              <li key={i} className="flex justify-between gap-4 text-gray-300">
+                <span>{item.factor}:</span>
+                <span className="text-red-400 font-bold">-{item.deduction}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="absolute left-1/2 -bottom-1 w-2 h-2 bg-gray-900 transform -translate-x-1/2 rotate-45"></div>
         </div>
       )}
     </div>

--- a/client/src/components/ResourceManager.tsx
+++ b/client/src/components/ResourceManager.tsx
@@ -116,7 +116,7 @@ const ResourceManager = () => {
                 <div className="flex items-start justify-between">
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
-                      <HealthRing score={item.healthScore ?? 100} size={28} strokeWidth={3} showText={false} />
+                      <HealthRing score={item.healthScore ?? 100} size={28} strokeWidth={3} showText={false} breakdown={item.healthScoreBreakdown} />
                       <span className="font-medium text-gray-900 dark:text-white truncate">{item.name}</span>
                       {item.openRequestsCount !== undefined && item.openRequestsCount > 0 && (
                         <Badge variant="danger" size="sm">
@@ -145,7 +145,7 @@ const ResourceManager = () => {
               {/* Header */}
               <div className="flex items-start justify-between">
                 <div className="flex items-center gap-4">
-                  <HealthRing score={selectedEquipment.healthScore ?? 100} size={64} strokeWidth={5} />
+                  <HealthRing score={selectedEquipment.healthScore ?? 100} size={64} strokeWidth={5} breakdown={selectedEquipment.healthScoreBreakdown} />
                   <div>
                     <h3 className="text-2xl font-bold text-gray-900 dark:text-white">{selectedEquipment.name}</h3>
                     <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">SN: {selectedEquipment.serialNumber}</p>

--- a/client/src/pages/EquipmentList.tsx
+++ b/client/src/pages/EquipmentList.tsx
@@ -228,7 +228,7 @@ const EquipmentList: React.FC = () => {
                   {/* Header */}
                   <div className="flex justify-between items-start mb-4">
                     <div className="flex items-center gap-3">
-                      <HealthRing score={item.healthScore ?? 100} size={40} strokeWidth={4} />
+                      <HealthRing score={item.healthScore ?? 100} size={40} strokeWidth={4} breakdown={item.healthScoreBreakdown} />
                       <h3 className="font-semibold text-lg text-gray-900 dark:text-white">
                         {item.name}
                       </h3>

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -26,6 +26,7 @@ export interface Equipment {
   defaultTechnician?: TeamMember;
   openRequestsCount?: number;
   healthScore?: number;
+  healthScoreBreakdown?: { factor: string; deduction: number }[];
   mapCoordinates?: { x: number; y: number };
   hourlyDowntimeCost?: number;
   createdAt?: string;

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -21,6 +21,15 @@ export default {
           800: '#075985',
           900: '#0c4a6e',
         }
+      },
+      keyframes: {
+        criticalPulse: {
+          '0%, 100%': { transform: 'scale(1)', filter: 'drop-shadow(0 0 8px rgba(239, 68, 68, 0.6))' },
+          '50%': { transform: 'scale(1.05)', filter: 'drop-shadow(0 0 16px rgba(239, 68, 68, 1))' },
+        }
+      },
+      animation: {
+        'critical-pulse': 'criticalPulse 1.5s ease-in-out infinite',
       }
     },
   },

--- a/server/models/Equipment.js
+++ b/server/models/Equipment.js
@@ -29,6 +29,10 @@ const EquipmentSchema = new Schema({
     type: Number,
     default: 100
   },
+  healthScoreBreakdown: [{
+    factor: { type: String },
+    deduction: { type: Number }
+  }],
   riskLevel: {
     type: String,
     default: "Healthy"

--- a/server/services/healthScoreService.js
+++ b/server/services/healthScoreService.js
@@ -6,6 +6,7 @@ async function calculateAndUpdateHealthScore(equipmentId) {
     if (!equipment) return null;
 
     let score = 100;
+    const breakdown = [];
 
     // 1. Age Penalty: -1 point for every 6 months of age
     if (equipment.purchaseDate) {
@@ -14,7 +15,10 @@ async function calculateAndUpdateHealthScore(equipmentId) {
       const monthsDiff = (now.getFullYear() - purchaseDate.getFullYear()) * 12 + (now.getMonth() - purchaseDate.getMonth());
       if (monthsDiff > 0) {
         const agePenalty = Math.floor(monthsDiff / 6);
-        score -= agePenalty;
+        if (agePenalty > 0) {
+          score -= agePenalty;
+          breakdown.push({ factor: 'Age Penalty', deduction: agePenalty });
+        }
       }
     }
 
@@ -25,7 +29,11 @@ async function calculateAndUpdateHealthScore(equipmentId) {
       type: 'corrective',
       createdAt: { $gte: thirtyDaysAgo }
     });
-    score -= recentBreakdowns * 10;
+    if (recentBreakdowns > 0) {
+      const deduction = recentBreakdowns * 10;
+      score -= deduction;
+      breakdown.push({ factor: 'Recent Breakdowns', deduction });
+    }
 
     // 3. Overdue Penalty: -15 points for every open ticket that is currently overdue
     const openStages = ['new', 'in-progress'];
@@ -34,14 +42,21 @@ async function calculateAndUpdateHealthScore(equipmentId) {
       stage: { $in: openStages },
       scheduledDate: { $lt: new Date() }
     });
-    score -= overdueTickets * 15;
+    if (overdueTickets > 0) {
+      const deduction = overdueTickets * 15;
+      score -= deduction;
+      breakdown.push({ factor: 'Overdue Tickets', deduction });
+    }
 
     // 4. Floor the score at 0
     score = Math.max(0, score);
 
-    // Update equipment if score changed
+    // Always update breakdown, and update score if changed
+    let updated = false;
+    
     if (equipment.healthScore !== score) {
       equipment.healthScore = score;
+      updated = true;
       
       // Optionally update riskLevel based on score
       if (score >= 75) {
@@ -51,9 +66,12 @@ async function calculateAndUpdateHealthScore(equipmentId) {
       } else {
         equipment.riskLevel = 'Critical';
       }
-
-      await equipment.save();
     }
+
+    // Checking if breakdown changed is trickier, so we just update it
+    // Mongoose handles modified checking
+    equipment.healthScoreBreakdown = breakdown;
+    await equipment.save();
 
     return score;
   } catch (error) {


### PR DESCRIPTION
## 📌 Pull Request Title

implement health score breakdown tooltips and critical pulse animation (#152)

---

## 🚀 Description

Enhances the predictive Health Score Rings by adding interactive context and urgent visual cues for failing equipment, making it easier for users to quickly diagnose health score drops and spot critical machines on a crowded dashboard.

---

## 🔗 Related Issue

Closes #152 

---

## 📝 Changes Made

- **Backend Context Tracking**: Updated `healthScoreService.js` to track the exact reasons for score deductions (e.g. Age Penalty, Recent Breakdowns, Overdue Tickets) during calculation. Added a new `healthScoreBreakdown` schema field to the `Equipment` model to store these itemized deductions.
- **Contextual Tooltips**: Updated the `HealthRing` React component to include a sleek, dark-themed hover tooltip that displays the `healthScoreBreakdown`. 
- **Critical Pulse Effect**: Added a custom `criticalPulse` CSS keyframe animation in `tailwind.config.js`. This causes the ring to subtly "pulse" or throb like a heartbeat when its score enters the critical zone (< 40%).
- **Global Integration**: Passed the new `breakdown` data into all instances of `<HealthRing />` across the application (Resource Manager, Equipment Grid, and Equipment Detail Modal).

---
## UI
<img width="712" height="359" alt="Screenshot 2026-05-28 at 23 33 13" src="https://github.com/user-attachments/assets/d1e4d94f-3c88-432b-9714-d136a8a65389" />
<img width="1160" height="687" alt="Screenshot 2026-05-28 at 23 33 39" src="https://github.com/user-attachments/assets/a77b2e66-eb55-4872-b855-f5cbe928ab1a" />

## 🧪 Testing Performed

- [x] Tested locally
- [x] Templates render correctly on GitHub

---

## 🏷️ NSoC'26 Information

- **Level:** Level 3
- **Points:** 10

---

## ✅ Checklist

- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] This PR does not break existing functionality
- [x] I have added necessary documentation

---

## ⚠️ Important

- PR without issue assignment will be **rejected**
- Missing `NSoC'26` tag will be **requested for update**

---

Thank you for your contribution! 🎉