### PR TITLE
Fix icon and label stacking in Button component

### DIFF
--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -47,7 +47,7 @@ const Button: React.FC<ButtonProps> = ({
       className={clsx(baseStyles, variants[variant], sizes[size], className)}
       {...props}
     >
-      <span className="relative z-10">{children}</span>
+      <span className="relative z-10 inline-flex items-center gap-2"> {children} </span>
       {(variant === 'primary' || variant === 'gradient') && (
         <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-1000"></div>
       )}

--- a/client/src/components/QuickActionCards.tsx
+++ b/client/src/components/QuickActionCards.tsx
@@ -88,7 +88,7 @@ const QuickActionCards = ({ onNewTask }: QuickActionCardsProps) => {
           size="sm"
           className="w-full mt-4 hover:shadow-md"
         >
-          <Plus className="w-4 h-4 mr-2" />
+          <Plus className="w-4 h-4" />
           Add New To-Do
         </Button>
       </div>


### PR DESCRIPTION
## 📌 Pull Request Title

Fix icon and label stacking in the Button component
---

## 🚀 Description

Icons inside buttons were rendering above the label instead of beside it. The `children `span in `Button.tsx` was missing `inline-flex items-center gap-2`, causing the icon and text to stack vertically instead of sitting side by side.

---

## 🔗 Related Issue

Closes #166 

---

## 📝 Changes Made

-  [x] Added `inline-flex items-center gap-2` to the `children` span in `Button.tsx`

---

## 🧪 Testing Performed

- [x] Tested locally
- [x]  Verified icon and label render inline across `primary`, `secondary`, and `gradient `variants
- [x]  Confirmed shimmer overlay on `primary`/`gradient `variants still renders correctly behind text

---

## 🏷️ NSoC'26 Information

- **Level:** Level 1
- **Points:** 3

---

## ✅ Checklist

- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] This PR does not break existing functionality
- [x] I have added necessary documentation