### PR TITLE
fix(auth): Use single canonical gearguard_token and gearguard_user

### DIFF
--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -31,7 +31,7 @@ const SettingsPage: React.FC = () => {
     const fetchWebhooks = async () => {
       try {
         const res = await axios.get('/api/v1/webhooks', {
-          headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
+          headers: { Authorization: `Bearer ${localStorage.getItem('gearguard_token')}` }
         });
         setWebhooks(res.data.data);
       } catch (err) {
@@ -45,7 +45,7 @@ const SettingsPage: React.FC = () => {
     if (!newWebhook.url) return toast.error("URL is required");
     try {
       const res = await axios.post('/api/v1/webhooks', newWebhook, {
-        headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
+        headers: { Authorization: `Bearer ${localStorage.getItem('gearguard_token')}` }
       });
       setWebhooks([res.data.data, ...webhooks]);
       setNewWebhook({ ...newWebhook, url: '' });
@@ -58,7 +58,7 @@ const SettingsPage: React.FC = () => {
   const handleDeleteWebhook = async (id: string) => {
     try {
       await axios.delete(`/api/v1/webhooks/${id}`, {
-        headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
+        headers: { Authorization: `Bearer ${localStorage.getItem('gearguard_token')}` }
       });
       setWebhooks(webhooks.filter(w => w._id !== id));
       toast.success("Webhook deleted");
@@ -70,7 +70,7 @@ const SettingsPage: React.FC = () => {
   const handleTestWebhook = async (webhook: any) => {
     try {
       await axios.post('/api/v1/webhooks/test', { url: webhook.url, provider: webhook.provider }, {
-        headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
+        headers: { Authorization: `Bearer ${localStorage.getItem('gearguard_token')}` }
       });
       toast.success("Test payload sent!");
     } catch (err) {

--- a/client/src/services/authService.ts
+++ b/client/src/services/authService.ts
@@ -4,20 +4,16 @@ export const authService = {
   login: async (credentials: any) => {
     const response = await api.post('/auth/login', credentials);
     if (response.data.token) {
-      localStorage.setItem('token', response.data.token);
       localStorage.setItem('gearguard_token', response.data.token);
-      localStorage.setItem('user', JSON.stringify(response.data.user));
       localStorage.setItem('gearguard_user', JSON.stringify(response.data.user));
     }
     return response.data;
   },
 
   loginWithToken: async (token: string) => {
-    localStorage.setItem('token', token);
     localStorage.setItem('gearguard_token', token);
     const response = await api.get('/auth/me', { headers: { Authorization: `Bearer ${token}` } });
     if (response.data.user) {
-      localStorage.setItem('user', JSON.stringify(response.data.user));
       localStorage.setItem('gearguard_user', JSON.stringify(response.data.user));
     }
     return response.data;
@@ -31,11 +27,11 @@ export const authService = {
   },
 
   getCurrentUser: () => {
-    const userStr = localStorage.getItem('user') || localStorage.getItem('gearguard_user');
+    const userStr = localStorage.getItem('gearguard_user');
     return userStr ? JSON.parse(userStr) : null;
   },
 
   isAuthenticated: () => {
-    return !!(localStorage.getItem('token') || localStorage.getItem('gearguard_token'));
+    return !!localStorage.getItem('gearguard_token');
   }
 };


### PR DESCRIPTION
# Fix Authentication State & LocalStorage Key Duplication

## Closes #170 

## 🐛 Summary of the Issue
The application was suffering from inconsistent authentication states across browser refreshes and 401 unauthorized responses. This occurred because multiple duplicate `localStorage` keys were being used (`token` vs `gearguard_token`, and `user` vs `gearguard_user`). In some cases, the UI would still show an authenticated state while API requests failed due to missing or mismatched `Authorization` headers.

## 🛠️ Proposed Solution
This PR standardizes the application to use a **single canonical set of authentication keys**: `gearguard_token` and `gearguard_user`. It actively cleans up any leftover legacy keys during logout and ensures synchronization between the `AuthContext` and the `api.ts` interceptor.

## 📝 Details of Changes
- **`client/src/services/authService.ts`**:
  - Updated `login()` and `loginWithToken()` to write **only** the canonical `gearguard_token` and `gearguard_user` keys.
  - Updated `getCurrentUser()` and `isAuthenticated()` to read **only** the canonical keys.
  - Retained removal of legacy `token` and `user` keys in `logout()` to gracefully clean up clients migrating to this new version.
- **`client/src/pages/SettingsPage.tsx`**: 
  - Refactored manual API authorization headers to correctly pull the active `gearguard_token` instead of the legacy `token`.
- **`client/src/services/api.ts`**: 
  - Verified the 401 error interceptor safely wipes both canonical and legacy keys to guarantee no redirect loops or stale sessions.

## ✅ Acceptance Criteria Validated
- [x] After a user logs out, they are fully logged out (no stale `token` or `user` entries remain).
- [x] 401 unauthorized errors fully wipe local storage and redirect correctly.
- [x] After a hard refresh, the React auth state matches the presence of the `gearguard_token` exactly, ensuring the `Authorization` header is correctly attached to API calls.

## ⚠️ Notes for Reviewers
No backward compatibility issues are expected for end-users, as the `logout` function effectively patches older active sessions upon sign-out.
