### PR TITLE
feat: implement equipment history timeline (closes #165)

### DIFF
--- a/client/src/components/EquipmentDetailModal.tsx
+++ b/client/src/components/EquipmentDetailModal.tsx
@@ -10,7 +10,7 @@ import Spinner from './Spinner';
 import RequestModal from './RequestModal';
 import ExportButton from './ExportButton';
 import { exportEquipmentPDF } from '../services/exportService';
-import AuditTimeline from './AuditTimeline';
+import EquipmentHistoryTimeline from './EquipmentHistoryTimeline';
 import HealthRing from './HealthRing';
 import { QRCodeCanvas } from 'qrcode.react';
 import { QrCode } from 'lucide-react';
@@ -264,7 +264,7 @@ const EquipmentDetailModal: React.FC<EquipmentDetailModalProps> = ({
             </h4>
           </div>
           <div className="bg-slate-900 rounded-lg p-6 max-h-[400px] overflow-y-auto">
-            <AuditTimeline entityType="Equipment" entityId={equipment.id || equipment._id || ''} />
+            <EquipmentHistoryTimeline history={equipment.history || []} />
           </div>
         </div>
 

--- a/client/src/components/EquipmentHistoryTimeline.tsx
+++ b/client/src/components/EquipmentHistoryTimeline.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { EquipmentHistoryEvent } from '../types';
+import { formatDistanceToNow } from 'date-fns';
+import { ShoppingBag, Plus, Activity, CheckCircle, Users, Trash2, ShieldAlert } from 'lucide-react';
+import Badge from './Badge';
+
+interface EquipmentHistoryTimelineProps {
+  history: EquipmentHistoryEvent[];
+}
+
+const EquipmentHistoryTimeline: React.FC<EquipmentHistoryTimelineProps> = ({ history }) => {
+  if (!history || history.length === 0) {
+    return (
+      <div className="p-8 text-center border border-dashed border-slate-700 rounded-lg">
+        <ShieldAlert className="h-8 w-8 mx-auto text-slate-500 mb-2" />
+        <p className="text-slate-400">No major lifecycle events recorded yet.</p>
+      </div>
+    );
+  }
+
+  // Sort history newest first
+  const sortedHistory = [...history].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+  const getEventConfig = (eventType: string) => {
+    switch (eventType) {
+      case 'PURCHASED':
+        return { icon: <ShoppingBag className="h-4 w-4 text-blue-500" />, bg: 'bg-blue-500/20' };
+      case 'CREATED':
+        return { icon: <Plus className="h-4 w-4 text-emerald-500" />, bg: 'bg-emerald-500/20' };
+      case 'STATUS_CHANGE':
+        return { icon: <Activity className="h-4 w-4 text-amber-500" />, bg: 'bg-amber-500/20' };
+      case 'REPAIR_COMPLETED':
+        return { icon: <CheckCircle className="h-4 w-4 text-emerald-500" />, bg: 'bg-emerald-500/20' };
+      case 'ASSIGNED':
+        return { icon: <Users className="h-4 w-4 text-purple-500" />, bg: 'bg-purple-500/20' };
+      case 'SCRAPPED':
+        return { icon: <Trash2 className="h-4 w-4 text-red-500" />, bg: 'bg-red-500/20' };
+      default:
+        return { icon: <Activity className="h-4 w-4 text-slate-500" />, bg: 'bg-slate-500/20' };
+    }
+  };
+
+  const getEventBadgeVariant = (eventType: string) => {
+    switch (eventType) {
+      case 'PURCHASED': return 'info';
+      case 'CREATED': return 'success';
+      case 'STATUS_CHANGE': return 'warning';
+      case 'REPAIR_COMPLETED': return 'success';
+      case 'ASSIGNED': return 'default'; // Or custom purple if added to Badge.tsx
+      case 'SCRAPPED': return 'danger';
+      default: return 'default';
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flow-root">
+        <ul className="-mb-8">
+          {sortedHistory.map((event, idx) => {
+            const config = getEventConfig(event.eventType);
+            return (
+              <li key={event._id || idx}>
+                <div className="relative pb-8">
+                  {idx !== sortedHistory.length - 1 && (
+                    <span className="absolute top-4 left-4 -ml-px h-full w-0.5 bg-slate-700" aria-hidden="true" />
+                  )}
+                  <div className="relative flex space-x-3">
+                    <div>
+                      <span className={`h-8 w-8 rounded-full ${config.bg} flex items-center justify-center ring-8 ring-slate-900`}>
+                        {config.icon}
+                      </span>
+                    </div>
+                    <div className="flex min-w-0 flex-1 justify-between space-x-4 pt-1.5">
+                      <div>
+                        <p className="text-sm text-slate-300">
+                          <Badge variant={getEventBadgeVariant(event.eventType)} size="sm" className="mr-2">
+                            {event.eventType.replace('_', ' ')}
+                          </Badge>
+                          <span className="font-medium text-white">{event.userName || 'System'}</span>
+                        </p>
+                        
+                        <div className="mt-2 text-sm text-slate-400">
+                          <div className="bg-slate-800/50 p-3 rounded-md border border-slate-700/50">
+                            <span className="text-slate-300">{event.description}</span>
+                          </div>
+                        </div>
+                      </div>
+                      <div className="whitespace-nowrap text-right text-xs text-slate-500">
+                        {formatDistanceToNow(new Date(event.timestamp), { addSuffix: true })}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default EquipmentHistoryTimeline;

--- a/client/src/pages/EquipmentList.tsx
+++ b/client/src/pages/EquipmentList.tsx
@@ -25,6 +25,7 @@ import {
   Wrench,
   MapPin,
   Calendar,
+  Power,
 } from "lucide-react";
 
 import EquipmentModal from "../components/EquipmentModal";
@@ -75,6 +76,20 @@ const EquipmentList: React.FC = () => {
       "under-maintenance":
         "warning",
     } as const;
+
+    const handleStatusToggle = async (e: React.MouseEvent, item: Equipment) => {
+      e.stopPropagation();
+      if (item.status === 'scrapped' || item.status === 'under-maintenance') {
+        return;
+      }
+      const newStatus = item.status === 'active' ? 'inactive' : 'active';
+      try {
+        await equipmentService.update(item.id, { status: newStatus });
+        loadEquipment();
+      } catch (error) {
+        console.error("Failed to update status", error);
+      }
+    };
 
     const handleExport = () => {
       if (
@@ -233,18 +248,33 @@ const EquipmentList: React.FC = () => {
                       </h3>
                     </div>
 
-                    <Badge
-                      variant={
-                        statusColors[
-                          item
-                            .status
-                        ]
-                      }
-                    >
-                      {
-                        item.status
-                      }
-                    </Badge>
+                    <div className="flex items-center gap-2">
+                      {(item.status === 'active' || item.status === 'inactive') && (
+                        <button
+                          onClick={(e) => handleStatusToggle(e, item)}
+                          className={`p-1.5 rounded-full transition-colors ${
+                            item.status === 'active' 
+                              ? 'bg-green-100 text-green-600 hover:bg-green-200 dark:bg-green-900/30 dark:text-green-400' 
+                              : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400'
+                          }`}
+                          title={`Toggle to ${item.status === 'active' ? 'inactive' : 'active'}`}
+                        >
+                          <Power className="h-4 w-4" />
+                        </button>
+                      )}
+                      <Badge
+                        variant={
+                          statusColors[
+                            item
+                              .status
+                          ]
+                        }
+                      >
+                        {
+                          item.status
+                        }
+                      </Badge>
+                    </div>
                   </div>
 
                   {/* Info */}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -29,8 +29,18 @@ export interface Equipment {
   healthScoreBreakdown?: { factor: string; deduction: number }[];
   mapCoordinates?: { x: number; y: number };
   hourlyDowntimeCost?: number;
+  history?: EquipmentHistoryEvent[];
   createdAt?: string;
   updatedAt?: string;
+}
+
+export interface EquipmentHistoryEvent {
+  _id?: string;
+  eventType: 'PURCHASED' | 'CREATED' | 'STATUS_CHANGE' | 'REPAIR_COMPLETED' | 'ASSIGNED' | 'SCRAPPED';
+  description: string;
+  timestamp: string;
+  userId?: string;
+  userName?: string;
 }
 
 export interface MaintenanceTeam {

--- a/server/controllers/equipmentController.js
+++ b/server/controllers/equipmentController.js
@@ -120,6 +120,13 @@ exports.createEquipment = asyncHandler(async (req, res, next) => {
   if (payload.department) payload.department = payload.department.trim();
   if (payload.notes) payload.notes = payload.notes.trim();
 
+  payload.history = [{
+    eventType: payload.purchaseDate ? 'PURCHASED' : 'CREATED',
+    description: `Equipment registered${payload.purchaseDate ? ' with purchase date' : ''}.`,
+    userId: req.user?._id,
+    userName: req.user?.name || "System"
+  }];
+
   const equipment = await Equipment.create(payload);
 
   const equipmentWithRelations = await Equipment.findById(equipment._id)
@@ -159,9 +166,40 @@ exports.createEquipment = asyncHandler(async (req, res, next) => {
 exports.updateEquipment = asyncHandler(async (req, res, next) => {
   const payload = sanitizeBody(req.body);
   const oldDoc = await Equipment.findById(req.params.id);
+  
+  if (!oldDoc) {
+    throw new ErrorHandler("Equipment not found", ERROR_TYPES.NOT_FOUND_ERROR);
+  }
+
+  const historyEvents = [];
+  if (payload.status && payload.status !== oldDoc.status) {
+    historyEvents.push({
+      eventType: payload.status === 'scrapped' ? 'SCRAPPED' : 'STATUS_CHANGE',
+      description: `Status changed from ${oldDoc.status} to ${payload.status}`,
+      userId: req.user?._id,
+      userName: req.user?.name || "System"
+    });
+  }
+  if ((payload.assignedTo !== undefined && payload.assignedTo !== oldDoc.assignedTo) || 
+      (payload.department !== undefined && payload.department !== oldDoc.department)) {
+    const newAssigned = payload.assignedTo !== undefined ? payload.assignedTo : oldDoc.assignedTo;
+    const newDept = payload.department !== undefined ? payload.department : oldDoc.department;
+    historyEvents.push({
+      eventType: 'ASSIGNED',
+      description: `Assignment updated: ${newAssigned || 'Unassigned'} (${newDept || 'No Dept'})`,
+      userId: req.user?._id,
+      userName: req.user?.name || "System"
+    });
+  }
+
+  const updateQuery = { $set: payload };
+  if (historyEvents.length > 0) {
+    updateQuery.$push = { history: { $each: historyEvents } };
+  }
+
   const updatedEquipment = await Equipment.findByIdAndUpdate(
     req.params.id,
-    payload,
+    updateQuery,
     { new: true },
   )
     .populate("maintenanceTeam")

--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -193,7 +193,13 @@ exports.createRequest = async (req, res) => {
           payload.assignedToId = equipmentDoc.defaultTechnicianId;
 
         await Equipment.findByIdAndUpdate(equipmentDoc._id, {
-          status: "under-maintenance",
+          $set: { status: "under-maintenance" },
+          $push: { history: {
+            eventType: 'STATUS_CHANGE',
+            description: `Status changed to under-maintenance (Request Created)`,
+            userId: req.user?._id,
+            userName: req.user?.name || "System"
+          }}
         });
       }
     }
@@ -369,14 +375,26 @@ exports.updateRequest = async (req, res) => {
         payload.completedDate = new Date();
         if (request.equipmentId)
           await Equipment.findByIdAndUpdate(request.equipmentId, {
-            status: "active",
+            $set: { status: "active" },
+            $push: { history: {
+              eventType: 'REPAIR_COMPLETED',
+              description: `Request marked as repaired. Status changed to active.`,
+              userId: req.user?._id,
+              userName: req.user?.name || "System"
+            }}
           });
       }
       if (payload.stage === "scrap") {
         payload.completedDate = new Date();
         if (request.equipmentId)
           await Equipment.findByIdAndUpdate(request.equipmentId, {
-            status: "scrapped",
+            $set: { status: "scrapped" },
+            $push: { history: {
+              eventType: 'SCRAPPED',
+              description: `Request marked as scrap. Status changed to scrapped.`,
+              userId: req.user?._id,
+              userName: req.user?.name || "System"
+            }}
           });
       }
     }
@@ -569,7 +587,13 @@ exports.updateRequestStage = async (req, res) => {
       if (request.equipmentId) {
         const newStatus = stage === "scrap" ? "scrapped" : "active";
         await Equipment.findByIdAndUpdate(request.equipmentId, {
-          status: newStatus,
+          $set: { status: newStatus },
+          $push: { history: {
+            eventType: stage === "scrap" ? 'SCRAPPED' : 'REPAIR_COMPLETED',
+            description: `Request stage updated to ${stage}. Status changed to ${newStatus}.`,
+            userId: req.user?._id,
+            userName: req.user?.name || "System"
+          }}
         });
       }
     }

--- a/server/models/Equipment.js
+++ b/server/models/Equipment.js
@@ -64,7 +64,14 @@ const EquipmentSchema = new Schema({
   hourlyDowntimeCost: {
     type: Number,
     default: 0
-  }
+  },
+  history: [{
+    eventType: { type: String, enum: ['PURCHASED', 'CREATED', 'STATUS_CHANGE', 'REPAIR_COMPLETED', 'ASSIGNED', 'SCRAPPED'], required: true },
+    description: { type: String, required: true },
+    timestamp: { type: Date, default: Date.now },
+    userId: { type: Schema.Types.ObjectId, ref: 'User' },
+    userName: { type: String }
+  }]
 }, { timestamps: true });
 
 EquipmentSchema.virtual('maintenanceTeam', {


### PR DESCRIPTION
## 📌 Pull Request Title

 implement equipment history timeline

---

## 🚀 Description

Implemented the complete Equipment History Timeline to track the lifecycle and major events of an asset from purchase to scrap. Also fixed the "Edit Equipment" button in the Resource Manager by upgrading the `EquipmentModal` to support prefilling and update operations. 

---

## 🔗 Related Issue

Closes #165 

---

## 📝 Changes Made

- [x] Appended semantic `history` array to the `Equipment` MongoDB schema
- [x] Intercepted events in `equipmentController` and `requestController` to auto-log changes
- [x] Created visual `EquipmentHistoryTimeline.tsx` component with dynamic Lucide icons
- [x] Replaced generic AuditTimeline with the semantic Equipment History Timeline in details modal
- [x] Upgraded `EquipmentModal` to accept `initialEquipment` for editing support
- [x] Wired up the "Edit Equipment" button in `ResourceManager.tsx`

---
## UI
<img width="560" height="297" alt="Screenshot 2026-05-31 at 11 12 28" src="https://github.com/user-attachments/assets/382b7227-f7b8-47ec-92ea-dee7476bcf06" />
<img width="1280" height="832" alt="Screenshot 2026-05-31 at 11 12 33" src="https://github.com/user-attachments/assets/dcc4c374-b759-4ce4-b3ad-7913d29e7cd3" />


## 🧪 Testing Performed

- [x] Verified equipment creation, editing, and request lifecycle logs events to the DB correctly
- [x] Tested "Edit Equipment" modal prefilling and updating correctly
- [x] Tested locally without errors
---

## 🏷️ NSoC'26 Information

- **Level:** Level 3
- **Points:** 10

---

## ✅ Checklist

- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] This PR does not break existing functionality

---

## ⚠️ Important

- PR without issue assignment will be **rejected**
- Missing `NSoC'26` tag will be **requested for update**

---

Thank you for your contribution! 🎉