### PR TITLE
feat: implement backend pagination and server-side sorting for requests

### DIFF
--- a/client/src/components/DetailedRequestsTable.tsx
+++ b/client/src/components/DetailedRequestsTable.tsx
@@ -31,23 +31,35 @@ interface DetailedRequestsTableProps {
 
 const DetailedRequestsTable: React.FC<DetailedRequestsTableProps> = ({ onEdit }) => {
   const [requests, setRequests] = useState<MaintenanceRequest[]>([]);
-
   const [loading, setLoading] = useState(true);
-  type SortField = "createdAt" | "priority" | "stage";
 
+  type SortField = "createdAt" | "priority" | "stage";
   const [sortField, setSortField] = useState<SortField>("createdAt");
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
   const [expandedRow, setExpandedRow] = useState<string | null>(null);
 
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(20);
+  const [totalItems, setTotalItems] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+
   useEffect(() => {
     loadRequests();
-  }, []);
+  }, [page, limit, sortField, sortDirection]);
 
   const loadRequests = async () => {
+    setLoading(true);
     try {
-      const data = await requestService.getAll();
+      const data = await requestService.getAll({
+        page,
+        limit,
+        sortBy: sortField,
+        sortOrder: sortDirection,
+      });
 
-      setRequests(data);
+      setRequests(data.items);
+      setTotalItems(data.totalItems);
+      setTotalPages(data.totalPages);
     } catch (error) {
       console.error("Failed to load requests:", error);
     } finally {
@@ -73,26 +85,7 @@ const DetailedRequestsTable: React.FC<DetailedRequestsTableProps> = ({ onEdit })
     return request[field];
   };
 
-  const sortedRequests = [...requests].sort((a, b) => {
-    const aValue = getSortValue(a, sortField);
-    const bValue = getSortValue(b, sortField);
-
-    if (aValue === undefined) return 1;
-    if (bValue === undefined) return -1;
-
-    if (typeof aValue === "string" && typeof bValue === "string") {
-      return sortDirection === "asc"
-        ? aValue.localeCompare(bValue)
-        : bValue.localeCompare(aValue);
-    }
-
-    const aNum = typeof aValue === 'number' ? aValue : 0;
-    const bNum = typeof bValue === 'number' ? bValue : 0;
-
-    return sortDirection === "asc"
-      ? aNum - bNum
-      : bNum - aNum;
-  });
+  const sortedRequests = requests; // Already sorted by backend
 
   const handleExport = () => {
     if (!sortedRequests || sortedRequests.length === 0) return;
@@ -476,6 +469,49 @@ const DetailedRequestsTable: React.FC<DetailedRequestsTableProps> = ({ onEdit })
           </div>
         )}
       </div>
+
+      {!loading && totalItems > 0 && (
+        <div className="border-t border-gray-200 dark:border-gray-700 px-6 py-4 flex items-center justify-between">
+          <div className="flex items-center text-sm text-gray-500 dark:text-gray-400">
+            <span>Showing {(page - 1) * limit + 1} to {Math.min(page * limit, totalItems)} of {totalItems} results</span>
+            <span className="mx-4">|</span>
+            <span>Rows per page:</span>
+            <select
+              value={limit}
+              onChange={(e) => {
+                setLimit(Number(e.target.value));
+                setPage(1);
+              }}
+              className="ml-2 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-1 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+            >
+              <option value={10}>10</option>
+              <option value={20}>20</option>
+              <option value={50}>50</option>
+            </select>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Button 
+              variant="secondary" 
+              size="sm" 
+              onClick={() => setPage(p => Math.max(1, p - 1))}
+              disabled={page === 1}
+            >
+              Previous
+            </Button>
+            <span className="text-sm text-gray-700 dark:text-gray-300">
+              Page {page} of {totalPages}
+            </span>
+            <Button 
+              variant="secondary" 
+              size="sm" 
+              onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -45,8 +45,8 @@ const Dashboard: React.FC = () => {
   useEffect(() => {
     const loadData = async () => {
       try {
-        const [requests, equipment, teams, metrics] = await Promise.all([
-          requestService.getAll(),
+        const [requestsData, equipment, teams, metrics] = await Promise.all([
+          requestService.getAll({ limit: 1000 }),
           equipmentService.getAll(),
           teamService.getAllTeams(),
           adminService.getMetrics(),
@@ -56,8 +56,10 @@ const Dashboard: React.FC = () => {
           setLowStockCount(metrics.lowStockCount);
         }
 
+        const requests = requestsData.items;
+
         setStats({
-          totalRequests: requests.length,
+          totalRequests: requestsData.totalItems,
 
           newRequests: requests.filter((r) => r.stage === "new").length,
 

--- a/client/src/pages/KanbanBoard.tsx
+++ b/client/src/pages/KanbanBoard.tsx
@@ -432,13 +432,13 @@ const KanbanBoard: React.FC =
         try {
           const data =
             await requestService.getFiltered(
-              filters
+              { ...filters, limit: 1000 }
             );
 
-          setRequests(data);
+          setRequests(data.items);
 
           setResultCount(
-            data.length
+            data.totalItems
           );
         } catch (error) {
           console.error(

--- a/client/src/services/requestService.ts
+++ b/client/src/services/requestService.ts
@@ -1,5 +1,5 @@
 import api from './api';
-import { MaintenanceRequest, CreateMaintenanceRequestDto, RequestFilters } from '../types';
+import { MaintenanceRequest, CreateMaintenanceRequestDto, RequestFilters, PaginatedResponse } from '../types';
 import toast from 'react-hot-toast';
 
 export interface AnalyticsQuery {
@@ -31,12 +31,8 @@ export interface AnalyticsResponse {
 
 export const requestService = {
   getAll: async (
-    filters?: {
-      stage?: string;
-      type?: string;
-      teamId?: string;
-    }
-  ): Promise<MaintenanceRequest[]> => {
+    filters?: RequestFilters
+  ): Promise<PaginatedResponse<MaintenanceRequest>> => {
     const response = await api.get("/requests", {
       params: filters,
     });
@@ -121,13 +117,13 @@ export const requestService = {
 
   getFiltered: async (
     filters: RequestFilters
-  ): Promise<MaintenanceRequest[]> => {
+  ): Promise<PaginatedResponse<MaintenanceRequest>> => {
     const params = new URLSearchParams();
 
     Object.entries(filters).forEach(
       ([key, value]) => {
         if (
-          value &&
+          value !== undefined && value !== null &&
           value.toString().trim() !== ""
         ) {
           params.append(

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,5 +1,13 @@
 import { SparePart, PartUsedInput } from './inventory';
 
+export interface PaginatedResponse<T> {
+  items: T[];
+  page: number;
+  limit: number;
+  totalItems: number;
+  totalPages: number;
+}
+
 export interface Equipment {
   _id?: string;
   id: string;
@@ -216,14 +224,18 @@ export interface EquipmentFinancials {
 }
 
 export interface RequestFilters {
-  stage: string;
-  type: string;
-  priority: string;
-  teamId: string;
-  assignedToId: string;
-  startDate: string;
-  endDate: string;
-  search: string;
+  stage?: string;
+  type?: string;
+  priority?: string;
+  teamId?: string;
+  assignedToId?: string;
+  startDate?: string;
+  endDate?: string;
+  search?: string;
+  page?: number;
+  limit?: number;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
 }
 
 export const defaultFilters: RequestFilters = {
@@ -235,6 +247,10 @@ export const defaultFilters: RequestFilters = {
   startDate: '',
   endDate: '',
   search: '',
+  page: 1,
+  limit: 20,
+  sortBy: 'createdAt',
+  sortOrder: 'desc',
 };
 
 export interface SearchEquipmentResult {

--- a/docs/API.md
+++ b/docs/API.md
@@ -141,13 +141,37 @@ DELETE /api/members/:id
 
 ### Get All Requests
 ```http
-GET /api/requests?stage=new&type=corrective&teamId=uuid
+GET /api/requests?stage=new&type=corrective&teamId=uuid&page=1&limit=20&sortBy=createdAt&sortOrder=desc
 ```
 
 **Query Parameters:**
 - `stage`: Filter by stage (new, in-progress, repaired, scrap)
 - `type`: Filter by type (corrective, preventive)
 - `teamId`: Filter by team
+- `page`: Page number (default: 1)
+- `limit`: Items per page (default: 20)
+- `sortBy`: Field to sort by (e.g. `createdAt`, `priority`, `stage`)
+- `sortOrder`: `asc` or `desc` (default: `desc`)
+
+**Response:**
+```json
+{
+  "items": [
+    {
+      "id": "uuid",
+      "requestNumber": "REQ-202410-0001",
+      "subject": "Leaking Oil",
+      "stage": "new",
+      "priority": "high",
+      "type": "corrective"
+    }
+  ],
+  "page": 1,
+  "limit": 20,
+  "totalItems": 45,
+  "totalPages": 3
+}
+```
 
 ### Get Request by ID
 ```http

--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -90,6 +90,10 @@ exports.getAllRequests = async (req, res) => {
       startDate,
       endDate,
       search,
+      page = 1,
+      limit = 20,
+      sortBy = "createdAt",
+      sortOrder = "desc",
     } = req.query;
 
     const query = {};
@@ -122,15 +126,35 @@ exports.getAllRequests = async (req, res) => {
       ];
     }
 
-    const requests = await MaintenanceRequest.find(query)
-      .populate("equipment")
-      .populate("team")
-      .populate("assignedTo", "name email")
-      .populate("createdBy", "name email")
-      .populate("partsUsed.partId")
-      .sort({ createdAt: -1 });
+    const sortObject = {};
+    sortObject[sortBy] = sortOrder === "asc" ? 1 : -1;
 
-    res.json(requests);
+    const pageNum = parseInt(page, 10) || 1;
+    const limitNum = parseInt(limit, 10) || 20;
+    const skipNum = (pageNum - 1) * limitNum;
+
+    const [requests, totalItems] = await Promise.all([
+      MaintenanceRequest.find(query)
+        .populate("equipment")
+        .populate("team")
+        .populate("assignedTo", "name email")
+        .populate("createdBy", "name email")
+        .populate("partsUsed.partId")
+        .sort(sortObject)
+        .skip(skipNum)
+        .limit(limitNum),
+      MaintenanceRequest.countDocuments(query),
+    ]);
+
+    const totalPages = Math.ceil(totalItems / limitNum);
+
+    res.json({
+      items: requests,
+      page: pageNum,
+      limit: limitNum,
+      totalItems,
+      totalPages,
+    });
   } catch (error) {
     res.status(500).json({ error: error.message });
   }


### PR DESCRIPTION
## 📌 Pull Request Title

feat: Add API pagination and server-side sorting for maintenance requests

---

## 🚀 Description

This PR addresses performance bottlenecks when loading large datasets of maintenance requests. It implements backend pagination and server-side sorting on the `GET /api/requests` endpoint, and updates the frontend components to handle the new paginated envelope structure. This significantly improves UI rendering speeds, limits the payload size, and provides a smoother user experience, particularly for the Detailed Requests Table view.

---

## 🔗 Related Issue

Closes #196 

---

## 📝 Changes Made

- [x] Updated `requestController.js` to extract `page`, `limit`, `sortBy`, and `sortOrder` query parameters.
- [x] Implemented MongoDB `$skip` and `$limit` aggregations, executing concurrently with `countDocuments`.
- [x] Transformed `GET /api/requests` response from a flat array to a paginated envelope structure (`{ items, page, limit, totalItems, totalPages }`).
- [x] Created `PaginatedResponse<T>` interface in frontend types.
- [x] Refactored `DetailedRequestsTable` to use API-driven server-side sorting and added pagination UI controls (Previous/Next buttons & Rows per page selector).
- [x] Updated `KanbanBoard` and `Dashboard` components to fetch data seamlessly with a large limit override (`limit: 1000`) to preserve drag-and-drop mechanisms and accurate metric calculations.
- [x] Documented the new query parameters and response structure in `docs/API.md`.

---

## 🧪 Testing Performed

- [x] Tested locally
- [x] Verified Table Pagination and "Rows per page" selections functionality
- [x] Verified Table Server-side Sorting updates correctly
- [x] Verified Kanban board grouping and drag-and-drop works uninterrupted
- [x] Verified Dashboard widgets still accurately reflect total request numbers

---

## ✅ Checklist

- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] This PR does not break existing functionality
- [x] I have added necessary documentation

---
