### PR TITLE
fix: reset equipment status on ticket deletion

### DIFF
--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -692,6 +692,26 @@ exports.deleteRequest = async (req, res) => {
     await NotificationService.notifyRequestChange(io, "request_deleted", request);
 
     if (request.equipmentId) {
+      // Check if there are any remaining open requests for this equipment
+      const openRequestsCount = await MaintenanceRequest.countDocuments({
+        equipmentId: request.equipmentId,
+        stage: { $nin: ['repaired', 'scrap'] }
+      });
+
+      // If no open tickets remain, reset the equipment status to active
+      if (openRequestsCount === 0) {
+        await Equipment.findByIdAndUpdate(request.equipmentId, { status: 'active' });
+        
+        await logActivity({
+          type: 'equipment_updated',
+          title: 'Equipment Status Restored',
+          description: `${getDisplayName(request.equipment)} restored to active after ticket deletion.`,
+          userName: 'System',
+          entityType: 'equipment',
+          entityId: String(request.equipmentId)
+        });
+      }
+
       calculateAndUpdateHealthScore(request.equipmentId).catch(err => 
         console.error('Background health score update failed:', err)
       );


### PR DESCRIPTION
## 📌 Pull Request Title

fix: Reset equipment status to active upon ticket deletion

---

## 🚀 Description

This PR resolves a logic flaw where an equipment's status would permanently remain stuck in `under-maintenance` if its open maintenance ticket was deleted instead of completed. The system now correctly checks for any remaining open tickets upon deletion, and if none exist, restores the equipment's status back to `active`.

---

## 🔗 Related Issue

Closes #216 

---

## 📝 Changes Made

- [x] Modified `deleteRequest` in `server/controllers/requestController.js`.
- [x] Added a database query to count remaining open tickets for the equipment.
- [x] Added logic to update `Equipment.status` to `active` if the count is zero.
- [x] Added an activity log to track the status restoration.

---

## 🧪 Testing Performed

- [x] Tested locally by creating an equipment ticket and verifying status changed to `under-maintenance`.
- [x] Deleted the ticket and verified the status properly reverted to `active`.
- [x] Ensured deleting a *completed* ticket does not inadvertently modify equipment statuses.

---

## 🏷️ NSoC'26 Information

- **Level:** Level 3
- **Points:** 10

---

## ✅ Checklist
- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] This PR does not break existing functionality
- [x] I have added necessary documentation

---

## ⚠️ Important

- PR without issue assignment will be **rejected**
- Missing `NSoC'26` tag will be **requested for update**

---

Thank you for your contribution! 🎉