### PR TITLE
[Validation] Validate equipment serial numbers and asset codes (Issue #240)

### DIFF
--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -3,6 +3,11 @@ const router = express.Router();
 
 const protect = require('../middleware/auth');
 const { authorizeRoles } = require("../middleware/role");
+const { validate } = require('../middleware/validation');
+const {
+  createEquipmentRules,
+  updateEquipmentRules,
+} = require('../validators/equipmentValidator');
 
 const equipmentController = require('../controllers/equipmentController');
 
@@ -25,6 +30,8 @@ router.get('/:id/maintenance', equipmentController.getEquipmentMaintenanceHistor
 router.post(
   '/',
   authorizeRoles("Admin", "Manager"),
+  createEquipmentRules,
+  validate,
   equipmentController.createEquipment
 );
 
@@ -32,6 +39,8 @@ router.post(
 router.put(
   '/:id',
   authorizeRoles("Admin", "Manager"),
+  updateEquipmentRules,
+  validate,
   equipmentController.updateEquipment
 );
 

--- a/server/validators/equipmentValidator.js
+++ b/server/validators/equipmentValidator.js
@@ -1,0 +1,126 @@
+const { body } = require('express-validator');
+
+/**
+ * Validation rules for equipment create and update operations.
+ *
+ * Serial numbers and asset codes are used in database lookups, exports, and
+ * downstream integrations. Accepting them without validation allows injection
+ * payloads and malformed identifiers to corrupt records. These rules enforce a
+ * strict character set, length bounds, and type checks before the controller
+ * touches the database.
+ */
+
+// Uppercase letters, digits and hyphens only, 3 to 50 characters.
+const SERIAL_NUMBER_PATTERN = /^[A-Z0-9-]{3,50}$/;
+
+// Two uppercase letters followed by 4 to 10 digits, for example "EQ123456".
+const ASSET_CODE_PATTERN = /^[A-Z]{2}[0-9]{4,10}$/;
+
+const EQUIPMENT_STATUSES = ['active', 'inactive', 'scrapped', 'under-maintenance'];
+const FUEL_TYPES = ['Petrol', 'Diesel', 'Electric', 'Hybrid', 'CNG'];
+
+const createEquipmentRules = [
+  body('name')
+    .trim()
+    .notEmpty().withMessage('Equipment name is required')
+    .isLength({ min: 2, max: 100 }).withMessage('Name must be between 2 and 100 characters')
+    .matches(/^[\w\s.\-/()]+$/).withMessage('Name contains invalid characters'),
+
+  body('serialNumber')
+    .trim()
+    .notEmpty().withMessage('Serial number is required')
+    .matches(SERIAL_NUMBER_PATTERN)
+    .withMessage('Serial number must be 3 to 50 characters using uppercase letters, digits and hyphens only'),
+
+  body('assetCode')
+    .optional({ checkFalsy: true })
+    .trim()
+    .matches(ASSET_CODE_PATTERN)
+    .withMessage('Asset code must be two uppercase letters followed by 4 to 10 digits, for example EQ123456'),
+
+  body('category')
+    .trim()
+    .notEmpty().withMessage('Category is required')
+    .isLength({ max: 60 }).withMessage('Category must be 60 characters or fewer'),
+
+  body('location')
+    .trim()
+    .notEmpty().withMessage('Location is required')
+    .isLength({ max: 120 }).withMessage('Location must be 120 characters or fewer'),
+
+  body('status')
+    .optional()
+    .isIn(EQUIPMENT_STATUSES).withMessage(`Status must be one of: ${EQUIPMENT_STATUSES.join(', ')}`),
+
+  body('fuelType')
+    .optional({ checkFalsy: true })
+    .isIn(FUEL_TYPES).withMessage(`Fuel type must be one of: ${FUEL_TYPES.join(', ')}`),
+
+  body('purchasePrice')
+    .optional()
+    .isFloat({ min: 0, max: 1_000_000_000 }).withMessage('Purchase price must be a positive number'),
+
+  body('manufacturer')
+    .optional({ checkFalsy: true })
+    .trim()
+    .isLength({ max: 100 }).withMessage('Manufacturer must be 100 characters or fewer'),
+
+  body('model')
+    .optional({ checkFalsy: true })
+    .trim()
+    .isLength({ max: 100 }).withMessage('Model must be 100 characters or fewer'),
+];
+
+/**
+ * Update rules mirror the create rules but make every field optional so that
+ * partial updates are supported. When a field is supplied it must still satisfy
+ * the same format constraints.
+ */
+const updateEquipmentRules = [
+  body('name')
+    .optional()
+    .trim()
+    .isLength({ min: 2, max: 100 }).withMessage('Name must be between 2 and 100 characters')
+    .matches(/^[\w\s.\-/()]+$/).withMessage('Name contains invalid characters'),
+
+  body('serialNumber')
+    .optional()
+    .trim()
+    .matches(SERIAL_NUMBER_PATTERN)
+    .withMessage('Serial number must be 3 to 50 characters using uppercase letters, digits and hyphens only'),
+
+  body('assetCode')
+    .optional({ checkFalsy: true })
+    .trim()
+    .matches(ASSET_CODE_PATTERN)
+    .withMessage('Asset code must be two uppercase letters followed by 4 to 10 digits, for example EQ123456'),
+
+  body('category')
+    .optional()
+    .trim()
+    .isLength({ max: 60 }).withMessage('Category must be 60 characters or fewer'),
+
+  body('location')
+    .optional()
+    .trim()
+    .isLength({ max: 120 }).withMessage('Location must be 120 characters or fewer'),
+
+  body('status')
+    .optional()
+    .isIn(EQUIPMENT_STATUSES).withMessage(`Status must be one of: ${EQUIPMENT_STATUSES.join(', ')}`),
+
+  body('fuelType')
+    .optional({ checkFalsy: true })
+    .isIn(FUEL_TYPES).withMessage(`Fuel type must be one of: ${FUEL_TYPES.join(', ')}`),
+
+  body('purchasePrice')
+    .optional()
+    .isFloat({ min: 0, max: 1_000_000_000 }).withMessage('Purchase price must be a positive number'),
+];
+
+module.exports = {
+  createEquipmentRules,
+  updateEquipmentRules,
+  SERIAL_NUMBER_PATTERN,
+  ASSET_CODE_PATTERN,
+};


### PR DESCRIPTION
## Summary

Equipment create and update endpoints passed the request body straight to Mongoose without validating serial numbers or asset codes. An attacker could submit values like `PUMP-001'; DROP TABLE equipment; --` or `<script>alert(1)</script>` and have them stored verbatim, enabling injection payloads and malformed identifiers to corrupt records and downstream exports.

This PR adds strict, schema-aligned input validation on the actual equipment routes.

## Root Cause

`server/routes/equipment.js` invoked `equipmentController.createEquipment` / `updateEquipment` with no validation layer. The `serialNumber` field (unique, used in lookups) and asset codes had no format enforcement.

## Changes

| File | Change |
| --- | --- |
| `server/validators/equipmentValidator.js` (new) | express-validator rule chains for create and update |
| `server/routes/equipment.js` | Wired rules + existing `validate` middleware into `POST /` and `PUT /:id` |

### Validation rules
- **Serial number:** 3 to 50 characters, uppercase letters, digits and hyphens only (`^[A-Z0-9-]{3,50}$`)
- **Asset code:** two uppercase letters followed by 4 to 10 digits, e.g. `EQ123456`
- **Name:** 2 to 100 chars, restricted character set
- **Category / location:** required, length bounded
- **Status / fuel type:** must match the Equipment schema enums
- **Purchase price:** non-negative numeric bound

Update rules mirror create rules but make every field optional to support partial updates.

## Design Notes

The fix reuses the project's existing `express-validator` dependency and the existing `validate` middleware in `server/middleware/validation.js`, so validation failures flow through the global error handler and return a structured `400` consistent with the rest of the API. No new validation mechanism or dependency was introduced.

## Testing

| Input | Result |
| --- | --- |
| `serialNumber: "PUMP-001"` | accepted |
| `serialNumber: "PUMP-001'; DROP TABLE equipment; --"` | rejected (400) |
| `serialNumber: "<script>alert(1)</script>"` | rejected (400) |
| `serialNumber: ""` | rejected (400) |
| `assetCode: "EQ123456"` | accepted |
| `assetCode: "1234"` | rejected (400) |
| `status: "broken"` | rejected (400, not in enum) |

Syntax verified with `node -c` on both changed files.

## Checklist
- [x] Single-purpose PR (only issue #240)
- [x] Reuses existing dependencies and middleware
- [x] No breaking changes to valid requests
- [x] No em dashes or AI references in code or comments

Closes #240