### PR TITLE
[Security] Encrypt sensitive maintenance notes at rest (Issue #241)

### DIFF
--- a/server/models/MaintenanceRequest.js
+++ b/server/models/MaintenanceRequest.js
@@ -1,5 +1,6 @@
 const { mongoose } = require('../config/database');
 const { Schema } = mongoose;
+const { encryptField, decryptField } = require('../utils/fieldEncryption');
 
 const MaintenanceRequestSchema = new Schema({
   requestNumber: { type: String, required: true, unique: true },
@@ -14,7 +15,14 @@ const MaintenanceRequestSchema = new Schema({
   cost: { type: Number },
   partsCost: { type: Number, default: 0 },
   laborCost: { type: Number, default: 0 },
-  notes: { type: String },
+  // notes holds sensitive repair findings and cost commentary. It is encrypted
+  // at rest with AES-256-GCM via transparent get and set functions. It is not
+  // part of any text index, so encryption does not affect search.
+  notes: {
+    type: String,
+    set: encryptField,
+    get: decryptField,
+  },
   overdueNotified: {
     type: Boolean,
     default: false,
@@ -86,8 +94,10 @@ MaintenanceRequestSchema.virtual('createdBy', {
   justOne: true
 });
 
-MaintenanceRequestSchema.set('toObject', { virtuals: true });
-MaintenanceRequestSchema.set('toJSON', { virtuals: true });
+// getters: true ensures the decrypt getter on notes runs when a document is
+// serialized to an object or to JSON for API responses.
+MaintenanceRequestSchema.set('toObject', { virtuals: true, getters: true });
+MaintenanceRequestSchema.set('toJSON', { virtuals: true, getters: true });
 
 // Indexes for optimized filtered queries
 MaintenanceRequestSchema.index({ stage: 1 });

--- a/server/utils/fieldEncryption.js
+++ b/server/utils/fieldEncryption.js
@@ -1,0 +1,114 @@
+const crypto = require('crypto');
+
+/**
+ * Transparent field-level encryption for sensitive Mongoose string fields.
+ *
+ * Maintenance notes contain repair findings, safety observations and cost
+ * commentary that were stored in plaintext. A database snapshot or backup leak
+ * exposed all of it. This module provides AES-256-GCM authenticated encryption
+ * that can be attached to a schema path via get and set functions, so the
+ * controllers and the rest of the app continue to read and write plain strings.
+ *
+ * Encrypted values are tagged with a versioned prefix so that:
+ *  - decrypt can tell an encrypted value from a legacy plaintext value, which
+ *    keeps existing documents readable during a gradual migration;
+ *  - the format can evolve in future without ambiguity.
+ *
+ * Format: enc:v1:<iv_hex>:<authTag_hex>:<ciphertext_hex>
+ */
+
+const ALGORITHM = 'aes-256-gcm';
+const PREFIX = 'enc:v1:';
+const IV_BYTES = 12; // 96-bit nonce recommended for GCM
+
+let cachedKey = null;
+
+/**
+ * Derive a stable 32-byte key. A dedicated key is preferred; if it is not set
+ * the function falls back to deriving one from JWT_SECRET so the feature still
+ * works in development. Returns null when no secret material is available, in
+ * which case encryption is skipped and values pass through unchanged.
+ */
+function getKey() {
+  if (cachedKey) return cachedKey;
+
+  const explicit = process.env.MAINTENANCE_LOG_ENCRYPTION_KEY;
+  if (explicit && explicit.length >= 64) {
+    cachedKey = Buffer.from(explicit.slice(0, 64), 'hex');
+    return cachedKey;
+  }
+
+  const fallbackSecret = process.env.JWT_SECRET;
+  if (fallbackSecret) {
+    cachedKey = crypto.createHash('sha256').update(fallbackSecret).digest();
+    return cachedKey;
+  }
+
+  return null;
+}
+
+function isEncrypted(value) {
+  return typeof value === 'string' && value.startsWith(PREFIX);
+}
+
+function encryptField(plaintext) {
+  if (plaintext === null || plaintext === undefined || plaintext === '') {
+    return plaintext;
+  }
+
+  // Avoid double encryption if a value is written back unchanged.
+  if (isEncrypted(plaintext)) {
+    return plaintext;
+  }
+
+  const key = getKey();
+  if (!key) {
+    return plaintext;
+  }
+
+  const iv = crypto.randomBytes(IV_BYTES);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+
+  const encrypted = Buffer.concat([
+    cipher.update(String(plaintext), 'utf8'),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return `${PREFIX}${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
+}
+
+function decryptField(value) {
+  if (!isEncrypted(value)) {
+    // Legacy plaintext or empty value: return as is.
+    return value;
+  }
+
+  const key = getKey();
+  if (!key) {
+    return value;
+  }
+
+  try {
+    const [, , ivHex, authTagHex, dataHex] = value.split(':');
+    const iv = Buffer.from(ivHex, 'hex');
+    const authTag = Buffer.from(authTagHex, 'hex');
+    const data = Buffer.from(dataHex, 'hex');
+
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(authTag);
+
+    const decrypted = Buffer.concat([decipher.update(data), decipher.final()]);
+    return decrypted.toString('utf8');
+  } catch (error) {
+    console.error('[fieldEncryption] Failed to decrypt value:', error.message);
+    return value;
+  }
+}
+
+module.exports = {
+  encryptField,
+  decryptField,
+  isEncrypted,
+  PREFIX,
+};


### PR DESCRIPTION
## Summary

Maintenance request `notes` hold repair findings, safety observations and cost commentary, and were persisted in plaintext. Any database snapshot or backup leak exposed this business-sensitive data. This PR adds transparent AES-256-GCM field-level encryption so the value is ciphertext at rest while the application keeps reading and writing plain strings.

## Changes

| File | Change |
| --- | --- |
| `server/utils/fieldEncryption.js` (new) | Reusable AES-256-GCM authenticated encryption with a versioned format |
| `server/models/MaintenanceRequest.js` | `set`/`get` functions on `notes`; `getters: true` on toObject/toJSON |

### Encrypted format
```
enc:v1:<iv_hex>:<authTag_hex>:<ciphertext_hex>
```
The prefix lets `decrypt` distinguish ciphertext from legacy plaintext, so existing documents stay readable during a gradual rollout, and values are never double-encrypted.

## Design Decisions

- **`description` is intentionally excluded.** It backs the model's text search index (`subject`, `requestNumber`, `description`). Encrypting it would break search. `notes` is not indexed, so encryption has zero functional impact on queries.
- **Authenticated encryption (GCM)** detects tampering via the auth tag.
- **Key management:** `MAINTENANCE_LOG_ENCRYPTION_KEY` (32-byte hex) is preferred, with a JWT_SECRET-derived fallback for development. If no secret exists, values pass through rather than throwing, so the app never crashes on a misconfiguration.

## Testing

Functional round-trip (run with a test secret):

| Check | Result |
| --- | --- |
| `encrypt` produces tagged ciphertext | pass |
| ciphertext differs from plaintext | pass |
| `decrypt(encrypt(x)) === x` | pass |
| legacy plaintext passes through | pass |
| empty/undefined handled | pass |
| no double-encryption | pass |

Syntax verified with `node -c` on both files.

## Checklist
- [x] Single-purpose PR (only issue #241)
- [x] Non-breaking: search index and existing documents preserved
- [x] Authenticated encryption (AES-256-GCM)
- [x] No em dashes or AI references in code or comments

Closes #241