### PR TITLE
[Audit] Add audit logging to supplier and purchase order operations (Issue #242)

### DIFF
--- a/server/controllers/purchaseOrderController.js
+++ b/server/controllers/purchaseOrderController.js
@@ -1,6 +1,7 @@
 const { PurchaseOrder, SparePart } = require('../models');
 const { ErrorHandler, ERROR_TYPES } = require('../utils/errorHandler');
 const { asyncHandler } = require('../middleware/errorHandler');
+const { auditLog } = require('../utils/auditLogger');
 
 // Get all purchase orders
 exports.getPurchaseOrders = asyncHandler(async (req, res, next) => {
@@ -16,6 +17,15 @@ exports.getPurchaseOrders = asyncHandler(async (req, res, next) => {
 exports.createPurchaseOrder = asyncHandler(async (req, res, next) => {
   const poNumber = 'PO-' + Math.floor(100000 + Math.random() * 900000);
   const po = await PurchaseOrder.create({ ...req.body, poNumber });
+
+  await auditLog({
+    entityType: 'PurchaseOrder',
+    entityId: po._id,
+    action: 'CREATE',
+    userId: req.user?._id,
+    userName: req.user?.name || '',
+  });
+
   res.status(201).json(po);
 });
 
@@ -29,6 +39,10 @@ exports.updatePurchaseOrderStatus = asyncHandler(async (req, res, next) => {
   if (!['draft', 'sent', 'received', 'cancelled'].includes(status)) {
     throw new ErrorHandler("Invalid status provided", ERROR_TYPES.VALIDATION_ERROR);
   }
+
+  // Capture the current status before the transaction for the audit diff.
+  const existingPO = await PurchaseOrder.findById(id).select('status');
+  const previousStatus = existingPO ? existingPO.status : null;
 
   const updatedPO = await withTransactionFallback(async (session) => {
     const po = await PurchaseOrder.findById(id).session(session);
@@ -60,6 +74,18 @@ exports.updatePurchaseOrderStatus = asyncHandler(async (req, res, next) => {
     return await PurchaseOrder.findById(id).session(session);
   });
 
+  // Record the status transition. Approving or receiving a PO is a financially
+  // significant action that commits spend and adjusts inventory.
+  await auditLog({
+    entityType: 'PurchaseOrder',
+    entityId: updatedPO._id,
+    action: 'UPDATE',
+    oldDoc: { status: previousStatus },
+    newDoc: { status },
+    userId: req.user?._id,
+    userName: req.user?.name || '',
+  });
+
   res.status(200).json({
     success: true,
     message: `Purchase Order status updated to ${status}`,
@@ -71,10 +97,18 @@ exports.updatePurchaseOrderStatus = asyncHandler(async (req, res, next) => {
 exports.deletePurchaseOrder = asyncHandler(async (req, res, next) => {
   const { id } = req.params;
   const po = await PurchaseOrder.findByIdAndDelete(id);
-  
+
   if (!po) {
     throw new ErrorHandler("Purchase Order not found", ERROR_TYPES.NOT_FOUND_ERROR);
   }
+
+  await auditLog({
+    entityType: 'PurchaseOrder',
+    entityId: po._id,
+    action: 'DELETE',
+    userId: req.user?._id,
+    userName: req.user?.name || '',
+  });
 
   res.status(200).json({
     success: true,

--- a/server/controllers/supplierController.js
+++ b/server/controllers/supplierController.js
@@ -1,6 +1,7 @@
 const { Supplier } = require('../models');
 const { ErrorHandler, ERROR_TYPES } = require('../utils/errorHandler');
 const { asyncHandler } = require('../middleware/errorHandler');
+const { auditLog } = require('../utils/auditLogger');
 
 // Get all suppliers
 exports.getSuppliers = asyncHandler(async (req, res, next) => {
@@ -30,6 +31,15 @@ exports.createSupplier = asyncHandler(async (req, res, next) => {
   const supplierData = { name, contactEmail, phone, leadTimeDays, notes };
   
   const supplier = await Supplier.create(supplierData);
+
+  await auditLog({
+    entityType: 'Supplier',
+    entityId: supplier._id,
+    action: 'CREATE',
+    userId: req.user?._id,
+    userName: req.user?.name || '',
+  });
+
   res.status(201).json(supplier);
 });
 
@@ -46,11 +56,23 @@ exports.updateSupplier = asyncHandler(async (req, res, next) => {
     }
   });
 
-  const supplier = await Supplier.findByIdAndUpdate(id, updateData, { new: true, runValidators: true });
-  
-  if (!supplier) {
+  // Capture the document before the change so the audit trail records a diff.
+  const oldDoc = await Supplier.findById(id);
+  if (!oldDoc) {
     throw new ErrorHandler("Supplier not found", ERROR_TYPES.NOT_FOUND_ERROR);
   }
+
+  const supplier = await Supplier.findByIdAndUpdate(id, updateData, { new: true, runValidators: true });
+
+  await auditLog({
+    entityType: 'Supplier',
+    entityId: supplier._id,
+    action: 'UPDATE',
+    oldDoc,
+    newDoc: supplier,
+    userId: req.user?._id,
+    userName: req.user?.name || '',
+  });
 
   res.status(200).json(supplier);
 });
@@ -63,6 +85,14 @@ exports.deleteSupplier = asyncHandler(async (req, res, next) => {
   if (!supplier) {
     throw new ErrorHandler("Supplier not found", ERROR_TYPES.NOT_FOUND_ERROR);
   }
+
+  await auditLog({
+    entityType: 'Supplier',
+    entityId: supplier._id,
+    action: 'DELETE',
+    userId: req.user?._id,
+    userName: req.user?.name || '',
+  });
 
   res.status(200).json({ success: true, message: 'Supplier deleted successfully' });
 });


### PR DESCRIPTION
## Summary

Extends the existing hash-chained audit trail to cover supplier and purchase order operations, which previously had **no accountability** despite carrying vendor and financial significance.

## Investigation

The repo already has audit infrastructure: `server/utils/auditLogger.js` writes hash-chained `AuditLog` entries, and `auditController.js` exposes `GET /api/v1/audit/verify` to validate ledger integrity. I confirmed it was already wired into `equipmentController` (CREATE/UPDATE/DELETE) and `requestController`.

The real gap behind issue #242 is that **other security-critical controllers never call it**:

| Controller | Destructive ops | Audit before | Audit after |
| --- | --- | --- | --- |
| supplierController | create / update / delete | none | CREATE, UPDATE, DELETE |
| purchaseOrderController | create / status change / delete | none | CREATE, UPDATE (status), DELETE |

So who created, modified or deleted a supplier, and who approved, received or deleted a purchase order, was completely untracked.

## Changes

- **`supplierController.js`**: logs CREATE, UPDATE and DELETE. UPDATE now fetches the prior document first so the audit entry records a field-level diff via the helper's `getChanges`.
- **`purchaseOrderController.js`**: logs CREATE, status transitions and DELETE. The status change captures the previous status, so approvals/receipts (which commit spend and adjust inventory) are attributable.

## Design Notes

Reuses the existing `auditLog` helper and its hash-chain ledger rather than introducing a parallel mechanism. New entries are verifiable through the same `GET /api/v1/audit/verify` endpoint as equipment and request entries, preserving a single tamper-evident chain.

## Testing

- `node -c` syntax verified on both controllers.
- The `auditLog` helper is non-blocking and already exercised in production paths by equipment/request controllers; the new calls follow the identical signature.

## Checklist
- [x] Single-purpose PR (only issue #242)
- [x] Reuses existing audit infrastructure (no parallel mechanism)
- [x] UPDATE entries capture field-level diffs
- [x] No em dashes or AI references in code or comments

Closes #242