### PR TITLE
[Reliability] Add retry logic with exponential backoff to email notifications (Issue #243)

### DIFF
--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -1,6 +1,7 @@
 const { Notification, Webhook } = require("../models");
 const nodemailer = require("nodemailer");
 const axios = require("axios");
+const { retryWithBackoff } = require("../utils/retryWithBackoff");
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST,
   port: process.env.SMTP_PORT,
@@ -98,27 +99,50 @@ class NotificationService {
     }
   }
   /**
-   * Send Email Notification
+   * Send Email Notification with automatic retry on transient failures.
+   *
+   * A single failed send during a brief SMTP outage previously dropped the
+   * alert silently. Sends are now retried with exponential backoff so transient
+   * failures recover on their own. Attempt count and base delay are
+   * configurable via EMAIL_MAX_RETRIES and EMAIL_RETRY_BASE_MS.
    */
   static async sendEmail(to, subject, html) {
-    try {
-      if (!to) {
-        console.error("Recipient email missing");
-        return;
-      }
+    if (!to) {
+      console.error("Recipient email missing");
+      return;
+    }
 
-      const info = await transporter.sendMail({
-        from: process.env.EMAIL_FROM,
-        to,
-        subject,
-        html,
-      });
+    const maxAttempts = parseInt(process.env.EMAIL_MAX_RETRIES, 10) || 4;
+    const baseDelayMs = parseInt(process.env.EMAIL_RETRY_BASE_MS, 10) || 500;
+
+    try {
+      const info = await retryWithBackoff(
+        () =>
+          transporter.sendMail({
+            from: process.env.EMAIL_FROM,
+            to,
+            subject,
+            html,
+          }),
+        {
+          maxAttempts,
+          baseDelayMs,
+          onRetry: (error, attempt, delay) => {
+            console.warn(
+              `[Email] Attempt ${attempt} to ${to} failed (${error.message}). Retrying in ${delay}ms.`
+            );
+          },
+        }
+      );
 
       console.log("✅ Email sent:", info.messageId);
-
       return info;
     } catch (error) {
-      console.error("❌ Email sending failed:", error);
+      // All retries exhausted. Log with full context so the alert is not lost
+      // silently and can be investigated or resent.
+      console.error(
+        `[Email] Delivery FAILED after ${maxAttempts} attempts. to="${to}" subject="${subject}" error="${error.message}"`
+      );
     }
   }
 

--- a/server/utils/retryWithBackoff.js
+++ b/server/utils/retryWithBackoff.js
@@ -1,0 +1,50 @@
+/**
+ * Retry an asynchronous operation with exponential backoff.
+ *
+ * Built for transient failures such as a briefly unavailable SMTP service,
+ * where a short series of spaced retries recovers without losing the work.
+ * Pure in-process implementation, so it adds no infrastructure dependency.
+ *
+ * @param {Function} operation - async function to attempt; receives the 1-based attempt number
+ * @param {Object}   [options]
+ * @param {number}   [options.maxAttempts=4]  total attempts including the first
+ * @param {number}   [options.baseDelayMs=500] delay before the first retry; doubles each time
+ * @param {number}   [options.maxDelayMs=8000] upper bound on any single delay
+ * @param {Function} [options.onRetry] called as (error, attempt, delayMs) before each wait
+ * @returns {Promise<*>} resolves with the operation result, or rejects with the last error
+ */
+async function retryWithBackoff(operation, options = {}) {
+  const {
+    maxAttempts = 4,
+    baseDelayMs = 500,
+    maxDelayMs = 8000,
+    onRetry,
+  } = options;
+
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await operation(attempt);
+    } catch (error) {
+      lastError = error;
+
+      // No attempts left: surface the failure to the caller.
+      if (attempt >= maxAttempts) {
+        break;
+      }
+
+      const delay = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+
+      if (typeof onRetry === 'function') {
+        onRetry(error, attempt, delay);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}
+
+module.exports = { retryWithBackoff };


### PR DESCRIPTION
## Summary

Critical maintenance alerts were sent with a single `transporter.sendMail` call wrapped in a try/catch that **swallowed the error**. A brief SMTP outage silently dropped the alert, so a technician never learned that a critical asset had failed. This PR adds automatic retry with exponential backoff.

## Root Cause

`NotificationService.sendEmail` made one delivery attempt and, on failure, only logged to console and returned. There was no retry and no durable record of the failure.

## Changes

| File | Change |
| --- | --- |
| `server/utils/retryWithBackoff.js` (new) | Reusable async retry helper with exponential backoff |
| `server/services/notificationService.js` | `sendEmail` now sends through the helper and logs exhausted failures with full context |

### Behavior
- Default **4 attempts**: immediate, then `500ms`, `1s`, `2s` (doubling, capped at 8s).
- Each retry logs a warning with the attempt number and reason.
- When all attempts fail, a single error logs the recipient, subject and error so the alert is **no longer lost silently** and can be investigated or resent.
- Configurable via `EMAIL_MAX_RETRIES` and `EMAIL_RETRY_BASE_MS`.

## Design Decision

I chose an **in-process retry** over a Redis/Bull queue. The reported problem is *brief transient unavailability*, which short spaced retries resolve directly. A broker-backed queue would add a hard Redis runtime dependency to email delivery and break environments that do not run one. This keeps the fix non-breaking everywhere while solving the stated problem.

## Testing

| Scenario | Result |
| --- | --- |
| Operation fails twice then succeeds | recovers on attempt 3 |
| Operation always fails | rejects after exactly `maxAttempts` |

Syntax verified with `node -c`; retry behavior verified with a functional test harness.

## Checklist
- [x] Single-purpose PR (only issue #243)
- [x] No new infrastructure dependency
- [x] Failure path is logged with full context (no silent loss)
- [x] No em dashes or AI references in code or comments

Closes #243