### PR TITLE
feat(tools): implement distributed concurrency control and real-time sync for tool crib

### DIFF
--- a/client/src/components/RequestToolsTab.tsx
+++ b/client/src/components/RequestToolsTab.tsx
@@ -6,6 +6,9 @@ import Button from './Button';
 import Badge from './Badge';
 import { Wrench, Loader2 } from 'lucide-react';
 import Spinner from './Spinner';
+import { io } from 'socket.io-client';
+
+const SOCKET_URL = import.meta.env.VITE_API_URL?.replace('/api/v1', '') || 'http://localhost:5000';
 
 interface RequestToolsTabProps {
   requestRecord: MaintenanceRequest;
@@ -20,6 +23,19 @@ const RequestToolsTab: React.FC<RequestToolsTabProps> = ({ requestRecord, onUpda
 
   useEffect(() => {
     fetchAvailableTools();
+
+    const socket = io(SOCKET_URL, {
+      auth: { token: localStorage.getItem('gearguard_token') }
+    });
+
+    socket.on('tools_changed', () => {
+      fetchAvailableTools();
+      onUpdate(); // Re-fetch the request record to reflect checkout/returns across clients if they affect this ticket
+    });
+
+    return () => {
+      socket.disconnect();
+    };
   }, [requestRecord]);
 
   const fetchAvailableTools = async () => {

--- a/client/src/pages/ToolCrib.tsx
+++ b/client/src/pages/ToolCrib.tsx
@@ -7,6 +7,9 @@ import Badge from '../components/Badge';
 import { Tool } from '../types';
 import toast from 'react-hot-toast';
 import { request } from '../utils/api';
+import { io } from 'socket.io-client';
+
+const SOCKET_URL = import.meta.env.VITE_API_URL?.replace('/api/v1', '') || 'http://localhost:5000';
 
 const ToolCrib: React.FC = () => {
   const { t } = useTranslation();
@@ -22,6 +25,18 @@ const ToolCrib: React.FC = () => {
 
   useEffect(() => {
     fetchTools();
+
+    const socket = io(SOCKET_URL, {
+      auth: { token: localStorage.getItem('gearguard_token') }
+    });
+
+    socket.on('tools_changed', () => {
+      fetchTools();
+    });
+
+    return () => {
+      socket.disconnect();
+    };
   }, []);
 
   const fetchTools = async () => {

--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -203,34 +203,6 @@ exports.createRequest = async (req, res) => {
     const payload = sanitizeBody(req.body);
     const requestNumber = await generateRequestNumber();
 
-    let equipmentDoc = null;
-    let oldEquipmentStatus = null;
-
-    if (payload.equipmentId) {
-      equipmentDoc = await Equipment.findById(payload.equipmentId)
-        .populate("maintenanceTeam")
-        .populate("defaultTechnician");
-
-      if (equipmentDoc) {
-        oldEquipmentStatus = equipmentDoc.status;
-
-        if (!payload.teamId && equipmentDoc.maintenanceTeamId)
-          payload.teamId = equipmentDoc.maintenanceTeamId;
-        if (!payload.assignedToId && equipmentDoc.defaultTechnicianId)
-          payload.assignedToId = equipmentDoc.defaultTechnicianId;
-
-        await Equipment.findByIdAndUpdate(equipmentDoc._id, {
-          $set: { status: "under-maintenance" },
-          $push: {
-            history: {
-              eventType: 'STATUS_CHANGE',
-              description: `Status changed to under-maintenance due to new request ${requestNumber}`,
-              date: new Date(),
-              recordedBy: req.user?._id,
-              notes: 'Status updated automatically on request creation'
-            }
-          }
-        });
     const requestWithRelations = await withTransactionFallback(async (session) => {
       let equipmentDoc = null;
       let oldEquipmentStatus = null;
@@ -269,21 +241,6 @@ exports.createRequest = async (req, res) => {
           );
         }
       }
-
-const request = await MaintenanceRequest.create({
-  ...payload,
-  requestNumber,
-  createdById: req.user?._id,
-  slaDeadline: calculateSLA(payload.priority || 'medium'),
-  attachments:
-    req.body.attachments || [],
-});
-    const requestWithRelations = await MaintenanceRequest.findById(request._id)
-      .populate("equipment")
-      .populate("team")
-      .populate("assignedTo", "name email")
-      .populate("createdBy", "name email")
-      .populate("partsUsed.partId");
       const request = await MaintenanceRequest.create([{
         ...payload,
         requestNumber,
@@ -431,49 +388,7 @@ exports.updateRequest = async (req, res) => {
     const prevRequest = await MaintenanceRequest.findById(req.params.id);
     if (!prevRequest) return res.status(404).json({ error: "Request not found" });
 
-    const request = await MaintenanceRequest.findById(req.params.id)
-      .populate("equipment")
-      .populate("createdBy", "name email");
-
-    if (!request) return res.status(404).json({ error: "Request not found" });
-
-    const prevStage = request.stage;
-    const prevPriority = request.priority;
-
-    // Handle stage side-effects (equipment status updates)
-    if (payload.stage) {
-      if (payload.stage === "repaired") {
-        payload.completedDate = new Date();
-        if (request.equipmentId) {
-          await Equipment.findByIdAndUpdate(request.equipmentId, {
-            $set: { status: "active" },
-            $push: {
-              history: {
-                eventType: 'STATUS_CHANGE',
-                description: `Status changed to active as request ${request.subject || request.requestNumber} was marked repaired`,
-                date: new Date(),
-                recordedBy: req.user?._id,
-                notes: 'Status updated automatically on request repaired'
-              }
-            }
-          });
-        }
-      }
-      if (payload.stage === "scrap") {
-        payload.completedDate = new Date();
-        if (request.equipmentId) {
-          await Equipment.findByIdAndUpdate(request.equipmentId, {
-            $set: { status: "scrapped" },
-            $push: {
-              history: {
-                eventType: 'STATUS_CHANGE',
-                description: `Status changed to scrapped as request ${request.subject || request.requestNumber} was marked scrap`,
-                date: new Date(),
-                recordedBy: req.user?._id,
-                notes: 'Status updated automatically on request scrapped'
-              }
-            }
-          });
+    // Non-transactional block removed
     const prevStage = prevRequest.stage;
     const prevPriority = prevRequest.priority;
     
@@ -1437,23 +1352,33 @@ exports.checkoutTool = async (req, res) => {
     const request = await MaintenanceRequest.findById(req.params.id);
     if (!request) return res.status(404).json({ error: "Request not found" });
 
-    const tool = await Tool.findById(toolId);
-    if (!tool) return res.status(404).json({ error: "Tool not found" });
-
-    if (tool.status !== 'Available') {
-      return res.status(400).json({ error: "Tool is not available for checkout" });
+    // Atomic update acts as a distributed lock
+    const tool = await Tool.findOneAndUpdate(
+      { _id: toolId, status: 'Available' },
+      { status: 'Checked Out' },
+      { new: true }
+    );
+    
+    if (!tool) {
+      return res.status(400).json({ error: "Tool is not available for checkout or does not exist" });
     }
-
-    tool.status = 'Checked Out';
-    await tool.save();
 
     request.checkedOutTools.push({ toolId: tool._id, checkedOutAt: new Date() });
     await request.save();
+
+    const io = req.app.get("socketio");
+    if (io) {
+      io.emit('tools_changed');
+    }
 
     const updatedReq = await MaintenanceRequest.findById(request._id)
       .populate('checkedOutTools.toolId');
 
     res.status(200).json(updatedReq);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};
 const isAuthorizedForRequest = (request, user) => {
   if (user.role === 'Admin' || user.role === 'Manager') return true;
   if (request.assignedToId && request.assignedToId.toString() === user._id.toString()) return true;
@@ -1531,19 +1456,28 @@ exports.returnTool = async (req, res) => {
     const request = await MaintenanceRequest.findById(req.params.id);
     if (!request) return res.status(404).json({ error: "Request not found" });
 
-    const tool = await Tool.findById(toolId);
-    if (!tool) return res.status(404).json({ error: "Tool not found" });
-
     request.checkedOutTools = request.checkedOutTools.filter(t => t.toolId.toString() !== toolId);
     await request.save();
 
-    tool.status = 'Available';
-    await tool.save();
+    const tool = await Tool.findOneAndUpdate(
+      { _id: toolId },
+      { status: 'Available' },
+      { new: true }
+    );
+
+    const io = req.app.get("socketio");
+    if (io) {
+      io.emit('tools_changed');
+    }
 
     const updatedReq = await MaintenanceRequest.findById(request._id)
       .populate('checkedOutTools.toolId');
 
     res.status(200).json(updatedReq);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};
 exports.downloadAttachment = async (req, res) => {
   try {
     const request = await MaintenanceRequest.findById(req.params.id);

--- a/server/controllers/toolController.js
+++ b/server/controllers/toolController.js
@@ -17,6 +17,10 @@ exports.createTool = asyncHandler(async (req, res, next) => {
     throw new ErrorHandler("Name and serial number are required", ERROR_TYPES.VALIDATION_ERROR);
   }
   const tool = await Tool.create(req.body);
+  
+  const io = req.app.get("socketio");
+  if (io) io.emit("tools_changed");
+
   res.status(201).json({
     success: true,
     data: tool
@@ -31,6 +35,10 @@ exports.updateTool = asyncHandler(async (req, res, next) => {
   if (!tool) {
     throw new ErrorHandler("Tool not found", ERROR_TYPES.NOT_FOUND_ERROR);
   }
+
+  const io = req.app.get("socketio");
+  if (io) io.emit("tools_changed");
+
   res.status(200).json({
     success: true,
     data: tool
@@ -42,6 +50,10 @@ exports.deleteTool = asyncHandler(async (req, res, next) => {
   if (!tool) {
     throw new ErrorHandler("Tool not found", ERROR_TYPES.NOT_FOUND_ERROR);
   }
+
+  const io = req.app.get("socketio");
+  if (io) io.emit("tools_changed");
+
   res.status(200).json({
     success: true,
     data: {}


### PR DESCRIPTION
### Title: feat(tools): implement distributed concurrency control and real-time sync for tool crib

### Description

## Closes #263 

**Issue**: The tool crib suffered from concurrency issues where multiple technicians could mistakenly check out the same tool simultaneously if they both had stale data open on their devices. Additionally, the tool crib inventory was only refreshed upon page load, leading to inconsistent views across users.

**Solution**:
1. **Atomic Checkouts (Distributed Lock)**: Instead of reading the tool's status into memory and then updating it, the backend now uses `Tool.findOneAndUpdate` with the condition `{ _id: toolId, status: 'Available' }`. This leverages MongoDB's native document-level locks to guarantee atomic updates, ensuring that only one request can ever successfully change a tool's status from 'Available' to 'Checked Out'.
2. **Real-Time Sync**: Implemented Socket.io event emissions (`tools_changed`) on the backend whenever a tool is created, updated, deleted, checked out, or returned. The frontend (`ToolCrib.tsx` and `RequestToolsTab.tsx`) now actively listens for these events and seamlessly re-fetches inventory data in the background, keeping all active users perfectly synchronized without manual refreshing.
3. **Bug Fixes**: Cleaned up duplicated and unclosed `try...catch` code blocks from a previous non-transactional merge in `requestController.js` that resulted in severe Node.js syntax crash errors (`Unexpected end of input`).

**Verification**:
- Verified backend code syntax with `node -c`.
- Verified frontend compilation with `npm run build`. 
- Manually confirmed the Socket connection lifecycle in the modified React components.