### PR TITLE
fix: Prevent negative numbers in inventory counts

### DIFF
--- a/server/controllers/inventoryController.js
+++ b/server/controllers/inventoryController.js
@@ -44,6 +44,9 @@ exports.getPartById = async (req, res) => {
 exports.createPart = async (req, res) => {
   try {
     const payload = { ...req.body };
+    if (payload.quantityInStock < 0 || payload.minReorderThreshold < 0) {
+      return res.status(400).json({ error: "Inventory quantities cannot be negative." });
+    }
     if (payload.quantityInStock !== undefined && payload.minReorderThreshold !== undefined) {
       payload.reorderStatus = payload.quantityInStock <= payload.minReorderThreshold ? 'low-stock' : 'ok';
     }
@@ -76,6 +79,10 @@ exports.updatePart = async (req, res) => {
     const quantity = payload.quantityInStock !== undefined ? payload.quantityInStock : prevPart.quantityInStock;
     const threshold = payload.minReorderThreshold !== undefined ? payload.minReorderThreshold : prevPart.minReorderThreshold;
     
+    if (quantity < 0 || threshold < 0) {
+      return res.status(400).json({ error: "Inventory quantities cannot be negative." });
+    }
+
     if (quantity > threshold) {
       payload.reorderStatus = 'ok';
     } else if (prevPart.reorderStatus === 'ok') {


### PR DESCRIPTION
## 📌 Pull Request Title

Prevent negative numbers in inventory counts

---

## 🚀 Description

Closes the bug where negative numbers could be entered and saved for inventory quantities.

---

## 🔗 Related Issue

Closes #277 

---

## 📝 Changes Made

Backend API Validation (inventoryController.js): Added strict validation checks to the createPart and updatePart endpoints. If the incoming payload contains a quantityInStock or minReorderThreshold that is less than 0, the server now explicitly rejects the request with a 400 Bad Request status and an error message, preventing the database from being corrupted with negative stock values.

---

## 🧪 Testing Performed

- Log in to the application and navigate to the Inventory page.
- Click Add Spare Part (or edit an existing part).
- Try to use your browser's developer tools or a tool like Postman to force the submission of a negative number (e.g., -5) for the "Quantity in Stock".
- Verify that the application throws an error and the negative inventory is not saved to the database.

---

## 🏷️ NSoC'26 Information

- **Level:** Level 3
- **Points:** 10

---

## ✅ Checklist

- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] This PR does not break existing functionality
- [x] I have added necessary documentation

---

## ⚠️ Important

- PR without issue assignment will be **rejected**
- Missing `NSoC'26` tag will be **requested for update**

---

Thank you for your contribution! 🎉