### PR TITLE
fix: [BUG] LOTO (Lockout/Tagout) Safety Enforcement Bypass in ToolCrib

### DIFF
--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -421,6 +421,31 @@ exports.updateRequest = async (req, res) => {
     const prevStage = prevRequest.stage;
     const prevPriority = prevRequest.priority;
     
+    // NEW LOTO CHECK
+    if (payload.stage === "in-progress" && prevStage !== "in-progress") {
+      const prevRequestWithEq = await MaintenanceRequest.findById(req.params.id).populate('equipment');
+      if (prevRequestWithEq && prevRequestWithEq.equipment?.lotoRequired) {
+        if (!prevRequestWithEq.lotoAudit || !prevRequestWithEq.lotoAudit.isCompleted) {
+          return res.status(400).json({ error: "LOTO Safety Audit is required before starting work on this equipment." });
+        }
+        
+        const Tool = require('../models/Tool');
+        let lotoToolFound = false;
+        if (prevRequestWithEq.checkedOutTools && prevRequestWithEq.checkedOutTools.length > 0) {
+          for (const t of prevRequestWithEq.checkedOutTools) {
+            const tool = await Tool.findById(t.toolId);
+            if (tool && tool.isLoto) {
+              lotoToolFound = true;
+              break;
+            }
+          }
+        }
+        if (!lotoToolFound) {
+          return res.status(403).json({ error: "Safety Violation: You must check out a LOTO lock from the Tool Crib before beginning work on this equipment." });
+        }
+      }
+    }
+    
     const request = await withTransactionFallback(async (session) => {
       // Handle stage side-effects (equipment status updates)
       if (payload.stage) {
@@ -649,6 +674,21 @@ exports.updateRequestStage = async (req, res) => {
     if (stage === "in-progress" && request.equipment?.lotoRequired) {
       if (!request.lotoAudit || !request.lotoAudit.isCompleted) {
         return res.status(400).json({ error: "LOTO Safety Audit is required before starting work on this equipment." });
+      }
+      
+      const Tool = require('../models/Tool');
+      let lotoToolFound = false;
+      if (request.checkedOutTools && request.checkedOutTools.length > 0) {
+        for (const t of request.checkedOutTools) {
+          const tool = await Tool.findById(t.toolId);
+          if (tool && tool.isLoto) {
+            lotoToolFound = true;
+            break;
+          }
+        }
+      }
+      if (!lotoToolFound) {
+        return res.status(403).json({ error: "Safety Violation: You must check out a LOTO lock from the Tool Crib before beginning work on this equipment." });
       }
     }
     
@@ -1554,8 +1594,16 @@ exports.returnTool = async (req, res) => {
   let lock;
   try {
     const { toolId } = req.body;
-    const request = await MaintenanceRequest.findById(req.params.id);
+    const request = await MaintenanceRequest.findById(req.params.id).populate('equipment');
     if (!request) return res.status(404).json({ error: "Request not found" });
+
+    const Tool = require('../models/Tool');
+    const toolToCheck = await Tool.findById(toolId);
+    if (toolToCheck && toolToCheck.isLoto) {
+      if (request.stage === "in-progress" && request.equipment && request.equipment.lotoRequired) {
+        return res.status(403).json({ error: "Safety Violation: You cannot return a LOTO lock while the high-risk ticket is still in-progress. Change the ticket stage first." });
+      }
+    }
 
     // Acquire lock for this specific tool for 5 seconds
     lock = await redlock.acquire([`tools:checkout:${toolId}`], 5000);

--- a/server/models/Tool.js
+++ b/server/models/Tool.js
@@ -6,6 +6,7 @@ const ToolSchema = new Schema({
   serialNumber: { type: String, required: true, unique: true },
   purchaseCost: { type: Number, default: 0 },
   status: { type: String, enum: ['Available', 'Checked Out', 'In Repair', 'Lost'], default: 'Available' },
+  isLoto: { type: Boolean, default: false },
 }, { timestamps: true });
 
 module.exports = mongoose.model('Tool', ToolSchema);


### PR DESCRIPTION
**Title:** fix: [BUG] LOTO (Lockout/Tagout) Safety Enforcement Bypass in ToolCrib

## Closes #293 

**Description:**

This PR implements a strict backend safety enforcement mechanism that completely blocks technicians from bypassing OSHA Lockout/Tagout procedures. High-risk maintenance tickets can no longer be transitioned to `in-progress` unless a designated LOTO asset is actively checked out, and the asset cannot be checked back into the ToolCrib while the ticket remains open.

**Key Architectural Changes:**

1. **Schema Enhancements:**
   - Appended a new `isLoto: { type: Boolean, default: false }` flag onto the `Tool` mongoose schema. This allows admins to categorize specific isolation locks and tags as safety-critical.

2. **Strict API Pre-Flight Blockers (Ticket Execution):**
   - Refactored `server/controllers/requestController.js` inside both `updateRequest` and `updateRequestStage`.
   - When transitioning a ticket to `in-progress`, the backend verifies if the parent equipment has `lotoRequired: true`.
   - If required, it aggressively scans the `checkedOutTools` array, performing a relational lookup to the `Tool` schema. If no active tool possessing `isLoto: true` is found, the payload is rejected with a hard `HTTP 403 Forbidden` safety violation error.

3. **Premature Tool Return Interceptors (ToolCrib):**
   - Modified `returnTool` in `server/controllers/requestController.js`.
   - If a technician attempts to return an `isLoto: true` lock, the engine queries their currently active `MaintenanceRequest` to verify the ticket status. If the ticket is still `in-progress` and requires LOTO, the check-in is physically blocked with a `HTTP 403 Forbidden` response, guaranteeing the machine cannot be theoretically powered on while work is underway.

**Verification Checklist:**
- [x] Tested transition blockers against standard vs. LOTO-required equipment profiles.
- [x] Verified `isLoto` Boolean evaluation inside ticket update payload scopes.
- [x] Simulated early return attempts of LOTO padlocks to confirm `HTTP 403` lockout.