### PR TITLE
fix: [BUG] Webhook Retry Amplification (Self-DDoS) on External API Outages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@socket.io/redis-adapter": "^8.3.0",
         "axios": "^1.16.1",
         "bcryptjs": "^3.0.3",
+        "bullmq": "^5.78.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
@@ -1100,6 +1101,84 @@
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
@@ -2306,6 +2385,96 @@
         "node": ">=0.2.0"
       }
     },
+    "node_modules/bullmq": {
+      "version": "5.78.0",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.78.0.tgz",
+      "integrity": "sha512-tT9jJmbobk9ueEfFc22egLmgwCcMGgOjZ5Y1cvgczBPv1JUmC7iHQVbQtqku2YBE5dE9uzdVpxIrBvL/YAjGwA==",
+      "license": "MIT",
+      "dependencies": {
+        "cron-parser": "4.9.0",
+        "ioredis": "5.10.1",
+        "msgpackr": "2.0.2",
+        "node-abort-controller": "3.1.1",
+        "semver": "7.8.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "peerDependencies": {
+        "redis": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "redis": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bullmq/node_modules/@ioredis/commands": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+      "license": "MIT"
+    },
+    "node_modules/bullmq/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bullmq/node_modules/ioredis": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.5.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/bullmq/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/bullmq/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -2814,6 +2983,18 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2921,6 +3102,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -5329,6 +5520,12 @@
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
       "license": "MIT"
     },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
@@ -5416,6 +5613,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -6047,6 +6253,37 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/msgpackr": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.2.tgz",
+      "integrity": "sha512-c5hYOXFbP79Slh6Dzd2wzk+jnV7mX1UxfMYtilnY1NmalXPqG8DGb5cYCMBrW4AsH3zekBBZd4QrKz9NhtvYLQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
     "node_modules/multer": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
@@ -6133,6 +6370,21 @@
       "license": "ISC",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@socket.io/redis-adapter": "^8.3.0",
     "axios": "^1.16.1",
     "bcryptjs": "^3.0.3",
+    "bullmq": "^5.78.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",

--- a/server/jobs/webhookDispatcher.js
+++ b/server/jobs/webhookDispatcher.js
@@ -1,107 +1,87 @@
 const axios = require('axios');
+const { Worker } = require('bullmq');
+const IORedis = require('ioredis');
 const WebhookEvent = require('../models/WebhookEvent');
-const { retryWithBackoff } = require('../utils/retryWithBackoff');
+const circuitBreaker = require('../utils/circuitBreaker');
+
+const connection = new IORedis(process.env.REDIS_URL || 'redis://localhost:6379', {
+  maxRetriesPerRequest: null
+});
 
 class WebhookDispatcher {
   constructor() {
-    this.intervalId = null;
-    this.isRunning = false;
-    this.POLL_INTERVAL_MS = 5000; // Poll every 5 seconds
-    this.BATCH_SIZE = 20; // Process 20 events per tick
+    this.worker = null;
   }
 
   start() {
-    if (this.intervalId) return;
-    console.log('[WebhookDispatcher] Starting queue polling...');
-    this.intervalId = setInterval(() => this.processQueue(), this.POLL_INTERVAL_MS);
-    
-    // Initial run
-    this.processQueue();
+    if (this.worker) return;
+    console.log('[WebhookDispatcher] Starting BullMQ worker...');
+
+    this.worker = new Worker('webhookQueue', async job => {
+      const { eventId, url, provider, payload } = job.data;
+
+      // 1. Mark as processing in MongoDB
+      await WebhookEvent.findByIdAndUpdate(eventId, { status: 'processing', attempts: job.attemptsMade + 1 });
+
+      // 2. Check Circuit Breaker
+      if (await circuitBreaker.isOpen(url)) {
+        const errorMsg = `Circuit is open for ${url}. Bouncing request.`;
+        console.warn(`[WebhookDispatcher] ${errorMsg}`);
+        await WebhookEvent.findByIdAndUpdate(eventId, {
+          $push: { errorLog: `Attempt ${job.attemptsMade + 1}: ${errorMsg}` }
+        });
+        throw new Error(errorMsg); // Throws so BullMQ retries (exponential backoff)
+      }
+
+      // 3. Format payload
+      let formattedPayload = {};
+      if (provider === 'Slack' || provider === 'Teams') {
+        formattedPayload = { text: JSON.stringify(payload, null, 2) };
+      } else if (provider === 'Discord') {
+        formattedPayload = { content: JSON.stringify(payload, null, 2) };
+      } else {
+        formattedPayload = payload;
+      }
+
+      // 4. Attempt the HTTP request
+      try {
+        const response = await axios.post(url, formattedPayload, { timeout: 10000 });
+        
+        // Success
+        await circuitBreaker.recordSuccess(url);
+        await WebhookEvent.findByIdAndUpdate(eventId, { status: 'completed', attempts: job.attemptsMade + 1 });
+        console.log(`[WebhookDispatcher] Event ${eventId} successfully dispatched.`);
+        
+        return response.data;
+      } catch (error) {
+        // Failure
+        await circuitBreaker.recordFailure(url);
+        await WebhookEvent.findByIdAndUpdate(eventId, {
+          $push: { errorLog: `Attempt ${job.attemptsMade + 1}: ${error.message}` }
+        });
+        throw error; // Throw so BullMQ can handle the retry logic natively
+      }
+    }, { connection, concurrency: 5 }); // Process up to 5 webhooks concurrently
+
+    this.worker.on('failed', async (job, err) => {
+      // If it has exhausted all 5 attempts natively, BullMQ emits 'failed' without 'retrying'
+      // We check if it's the final failure
+      if (job.attemptsMade >= job.opts.attempts) {
+        console.error(`[WebhookDispatcher] Event ${job.data.eventId} failed permanently:`, err.message);
+        await WebhookEvent.findByIdAndUpdate(job.data.eventId, { status: 'failed', attempts: job.attemptsMade });
+      }
+    });
+
+    this.worker.on('error', err => {
+      console.error('[WebhookDispatcher] BullMQ Worker Error:', err);
+    });
   }
 
   stop() {
-    if (this.intervalId) {
-      clearInterval(this.intervalId);
-      this.intervalId = null;
-      console.log('[WebhookDispatcher] Stopped queue polling.');
-    }
-  }
-
-  async processQueue() {
-    if (this.isRunning) return; // Prevent overlapping ticks
-    this.isRunning = true;
-
-    try {
-      // Find up to BATCH_SIZE pending events
-      const events = await WebhookEvent.find({ status: 'pending' })
-        .sort({ createdAt: 1 })
-        .limit(this.BATCH_SIZE);
-
-      if (events.length === 0) {
-        this.isRunning = false;
-        return;
-      }
-
-      console.log(`[WebhookDispatcher] Processing ${events.length} event(s)...`);
-
-      // We use Promise.allSettled to process them concurrently but handle individually
-      await Promise.allSettled(events.map(event => this.dispatchWithRetry(event)));
-
-    } catch (error) {
-      console.error('[WebhookDispatcher] Error during queue processing tick:', error);
-    } finally {
-      this.isRunning = false;
-    }
-  }
-
-  async dispatchWithRetry(event) {
-    // 1. Mark as processing
-    event.status = 'processing';
-    await event.save();
-
-    let attemptsMade = 0;
-
-    try {
-      // 2. Dispatch using resilient backoff utility
-      await retryWithBackoff(async (attempt) => {
-        attemptsMade = attempt;
-        
-        let formattedPayload = {};
-        
-        // Format payload based on provider
-        if (event.provider === 'Slack' || event.provider === 'Teams') {
-          formattedPayload = { text: JSON.stringify(event.payload, null, 2) };
-        } else if (event.provider === 'Discord') {
-          formattedPayload = { content: JSON.stringify(event.payload, null, 2) };
-        } else {
-          formattedPayload = event.payload; // fallback
-        }
-
-        const response = await axios.post(event.url, formattedPayload, { timeout: 10000 });
-        return response.data;
-      }, {
-        maxAttempts: 4, // 4 attempts max
-        baseDelayMs: 1000, // starting with 1s
-        maxDelayMs: 15000, // up to 15s
-        onRetry: (error, attempt, delay) => {
-          console.warn(`[WebhookDispatcher] Event ${event._id} attempt ${attempt} failed: ${error.message}. Retrying in ${delay}ms...`);
-          event.errorLog.push(`Attempt ${attempt}: ${error.message}`);
-        }
-      });
-
-      // 3. Mark completed if successful
-      event.status = 'completed';
-      event.attempts = attemptsMade;
-      await event.save();
-      console.log(`[WebhookDispatcher] Event ${event._id} successfully dispatched.`);
-
-    } catch (finalError) {
-      // 4. Mark as failed (Dead Letter Queue) after all retries exhausted
-      console.error(`[WebhookDispatcher] Event ${event._id} failed permanently:`, finalError.message);
-      event.status = 'failed';
-      event.attempts = attemptsMade;
-      event.errorLog.push(`Final Failure: ${finalError.message}`);
-      await event.save();
+    if (this.worker) {
+      this.worker.close();
+      this.worker = null;
+      console.log('[WebhookDispatcher] Stopped BullMQ worker.');
     }
   }
 }

--- a/server/services/webhookService.js
+++ b/server/services/webhookService.js
@@ -1,5 +1,13 @@
 const Webhook = require('../models/Webhook');
 const WebhookEvent = require('../models/WebhookEvent');
+const { Queue } = require('bullmq');
+const IORedis = require('ioredis');
+
+const connection = new IORedis(process.env.REDIS_URL || 'redis://localhost:6379', {
+  maxRetriesPerRequest: null
+});
+
+const webhookQueue = new Queue('webhookQueue', { connection });
 
 /**
  * Queue a webhook event for asynchronous dispatch.
@@ -30,9 +38,27 @@ exports.queueWebhookEvent = async (eventName, payload) => {
       errorLog: []
     }));
 
-    // Bulk insert into the queue
-    await WebhookEvent.insertMany(eventsToInsert);
-    console.log(`[WebhookService] Queued ${eventsToInsert.length} event(s) for trigger: ${eventName}`);
+    // Bulk insert into the MongoDB queue (acts as the DLQ / audit log)
+    const insertedEvents = await WebhookEvent.insertMany(eventsToInsert);
+
+    // Push jobs to BullMQ for robust processing
+    for (const event of insertedEvents) {
+      await webhookQueue.add('dispatchWebhook', {
+        eventId: event._id,
+        provider: event.provider,
+        url: event.url,
+        payload: event.payload
+      }, {
+        attempts: 5,
+        backoff: {
+          type: 'exponential',
+          delay: 1000 // 1s, 2s, 4s, 8s, 16s
+        },
+        removeOnComplete: true
+      });
+    }
+
+    console.log(`[WebhookService] Queued ${insertedEvents.length} event(s) to BullMQ for trigger: ${eventName}`);
   } catch (error) {
     console.error('[WebhookService] Failed to queue webhook event:', error);
   }

--- a/server/utils/circuitBreaker.js
+++ b/server/utils/circuitBreaker.js
@@ -1,0 +1,51 @@
+const Redis = require('ioredis');
+
+// Use the existing REDIS_URL from environment or fallback to localhost
+const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+const redis = new Redis(redisUrl);
+
+const FAILURE_THRESHOLD = 10;
+const OPEN_CIRCUIT_TTL = 15 * 60; // 15 minutes in seconds
+
+class CircuitBreaker {
+  /**
+   * Check if the circuit is open for a specific URL.
+   * @param {string} url - The URL to check
+   * @returns {boolean} True if the circuit is open and requests should be blocked
+   */
+  async isOpen(url) {
+    const isOpen = await redis.get(`circuit:${url}:open`);
+    return isOpen === 'true';
+  }
+
+  /**
+   * Record a failure for a specific URL. 
+   * If failures reach the threshold, it opens the circuit.
+   * @param {string} url - The URL that failed
+   */
+  async recordFailure(url) {
+    const key = `circuit:${url}:failures`;
+    const failures = await redis.incr(key);
+    
+    // Set expiry to reset failures if they are sporadic (e.g. 5 mins)
+    if (failures === 1) {
+      await redis.expire(key, 5 * 60);
+    }
+
+    if (failures >= FAILURE_THRESHOLD) {
+      console.warn(`[CircuitBreaker] Threshold reached for ${url}. Opening circuit for 15 minutes.`);
+      await redis.setex(`circuit:${url}:open`, OPEN_CIRCUIT_TTL, 'true');
+      await redis.del(key); // Reset counter
+    }
+  }
+
+  /**
+   * Record a success, which resets the failure counter.
+   * @param {string} url - The URL that succeeded
+   */
+  async recordSuccess(url) {
+    await redis.del(`circuit:${url}:failures`);
+  }
+}
+
+module.exports = new CircuitBreaker();


### PR DESCRIPTION
**Title:** fix: [BUG] Webhook Retry Amplification (Self-DDoS) on External API Outages

## Closes #294 

**Description:**

This PR completely overhauls the Webhook Dispatcher architecture, protecting GearGuard from catastrophic "Self-DDoS" conditions. Previously, during an external ERP system outage (HTTP 503/Timeouts), the system relied on volatile memory and an unbounded `setInterval` loop to manage webhook retries. If many tickets were closed concurrently during an outage, the Node.js event loop would infinitely spawn thousands of unhandled exponential-backoff promises, pinning the CPU at 100% and crashing the server.

This fix decouples retry-management from the Node event loop using `BullMQ` (a robust Redis-backed message queue) and introduces a sophisticated Circuit Breaker pattern.

**Key Architectural Changes:**

1. **Persistent Queue (BullMQ Integration):**
   - Ripped out the volatile `Promise.allSettled` loop in `server/jobs/webhookDispatcher.js`.
   - Initialized a native BullMQ `Worker` daemon. The system now seamlessly pushes outbound webhooks into a Redis `webhookQueue` using `Queue.add()`.
   - We utilized native BullMQ properties to configure `attempts: 5` and a strict `exponential` backoff schedule (1s, 2s, 4s, 8s, 16s). 
   - This ensures the Node event loop is never blocked by pending webhook retries.

2. **Dead-Letter Queue (DLQ):**
   - The MongoDB `WebhookEvent` model remains as our ultimate audit log.
   - If the BullMQ worker exhausts all 5 attempts, it triggers a `failed` event, updating the MongoDB `WebhookEvent` status to `failed`. This allows the record to persist securely as a Dead-Letter Queue for later admin inspection without infinitely circling in memory.

3. **Circuit Breaker Pattern:**
   - Engineered a standalone Redis-backed Circuit Breaker utility (`server/utils/circuitBreaker.js`).
   - Every time an `axios.post` fails, `recordFailure(url)` is called.
   - **Threshold Logic:** If a specific external endpoint accrues **10 failures** consecutively, the Circuit Breaker flips **OPEN** and writes a block to Redis with a 15-minute Time-To-Live (TTL).
   - Subsequent BullMQ retries targeting that URL instantly check `isOpen(url)`. If true, the expensive external HTTP network call is skipped entirely. This aggressively throttles traffic, preventing unnecessary network timeouts and giving the external ERP system room to recover.

**Verification Checklist:**
- [x] Verified `npm install bullmq` integration.
- [x] Tested BullMQ exponential backoff behavior under simulated external endpoint failure.
- [x] Confirmed the MongoDB Dead-Letter Queue `failed` state update after 5 exhausted attempts.
- [x] Triggered 10+ intentional webhook failures and confirmed the Circuit Breaker successfully blocks outbound network traffic for the prescribed 15-minute window.