### PR TITLE
Fix/geospatial dispatch crash 2

### DIFF
--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -266,14 +266,18 @@ exports.createRequest = async (req, res) => {
             const eqCoords = equipmentDoc.geoLocation.coordinates;
             // Only search if coordinates are not [0,0]
             if (eqCoords[0] !== 0 || eqCoords[1] !== 0) {
-              const nearestTech = await TeamMember.findOne({
+              const query = {
                 isActive: true,
                 geoLocation: {
                   $near: {
                     $geometry: { type: 'Point', coordinates: eqCoords }
                   }
                 }
-              }).session(session);
+              };
+              if (payload.requiredSkills && payload.requiredSkills.length > 0) {
+                query.certifications = { $all: payload.requiredSkills };
+              }
+              const nearestTech = await TeamMember.findOne(query).session(session);
 
               if (nearestTech) {
                 payload.assignedToId = nearestTech._id;


### PR DESCRIPTION
## 📌 Pull Request Title

Urgent Geospatial Dispatch Crash
---

## 🚀 Description

This PR resolves a critical bug where creating an `urgent` ticket would crash with a `400 Bad Request` if the nearest technician found by the geospatial routing engine lacked the required skills. 

---

## 🔗 Related Issue

Closes #304 

---

## 📝 Changes Made

* **Updated Geospatial Query (`requestController.js`):** Modified the `$near` geospatial MongoDB query used during ticket creation to also filter by `requiredSkills`. 
* **Added `$all` Matcher:** The auto-dispatch algorithm now dynamically injects a `$all` matcher against the technician's `certifications` array before running the coordinate search. 
* **Graceful Fallback:** The system now bypasses unqualified technicians and will route the ticket to the nearest technician who *actually possesses* the necessary certifications. If no nearby technicians are qualified, it gracefully falls back and leaves the ticket unassigned instead of aborting the request.

---

## 🧪 Testing Performed

* Verified that creating an urgent ticket requiring specific skills skips over closer, uncertified technicians and successfully assigns it to a further, but fully qualified, technician.
* Verified that if no one possesses the skills, the ticket is successfully created but left unassigned (ready for manual intervention), rather than crashing the system.

---

## 🏷️ NSoC'26 Information

- **Level:** Level 3
- **Points:** 10

---

## ✅ Checklist

- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] This PR does not break existing functionality
- [x] I have added necessary documentation

---

## ⚠️ Important

- PR without issue assignment will be **rejected**
- Missing `NSoC'26` tag will be **requested for update**

---

Thank you for your contribution! 🎉