### PR TITLE
fix: race condition in spare part inventory decrementing using occ

### DIFF
--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -96,6 +96,12 @@ api.interceptors.response.use(
 
     let message = 'Something went wrong';
     
+    if (error.response?.status === 409) {
+      message = error.response.data?.error || 'Concurrency Conflict: This record was modified by another user. Please refresh and try again.';
+      toast.error(message, { duration: 6000 });
+      return Promise.reject(error);
+    }
+    
     if (error.response?.data?.message) {
       message = error.response.data.message;
     } else if (error.response?.data?.error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "jsonwebtoken": "^9.0.3",
         "mongodb": "^7.2.0",
         "mongoose": "^7.8.8",
+        "mongoose-update-if-current": "^1.4.0",
         "morgan": "^1.10.0",
         "multer": "^2.1.1",
         "node-cron": "^4.2.1",
@@ -2912,6 +2913,17 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -6074,6 +6086,23 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
+    "node_modules/mongoose-update-if-current": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mongoose-update-if-current/-/mongoose-update-if-current-1.4.0.tgz",
+      "integrity": "sha512-Rau2nvdiLExqXrSOwMMgDYQgf/fwTJQpPidTcT7C9UMQ282gTKXjDuh5vrjVvVQpfuvkiPis0tGHdXffaD54bg==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js": "^3.2.1",
+        "kareem": "^2.3.0",
+        "regenerator-runtime": "^0.13.5"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "mongoose": ">=5.0.0"
+      }
+    },
     "node_modules/mongoose/node_modules/@types/whatwg-url": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
@@ -7277,6 +7306,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "jsonwebtoken": "^9.0.3",
     "mongodb": "^7.2.0",
     "mongoose": "^7.8.8",
+    "mongoose-update-if-current": "^1.4.0",
     "morgan": "^1.10.0",
     "multer": "^2.1.1",
     "node-cron": "^4.2.1",

--- a/server/controllers/inventoryController.js
+++ b/server/controllers/inventoryController.js
@@ -72,12 +72,15 @@ exports.createPart = async (req, res) => {
 // Update a spare part
 exports.updatePart = async (req, res) => {
   try {
-    const prevPart = await SparePart.findById(req.params.id);
-    if (!prevPart) return res.status(404).json({ error: "Spare part not found" });
+    const part = await SparePart.findById(req.params.id);
+    if (!part) return res.status(404).json({ error: "Spare part not found" });
+
+    // Store previous stock for logging
+    const prevStock = part.quantityInStock;
 
     const payload = { ...req.body };
-    const quantity = payload.quantityInStock !== undefined ? payload.quantityInStock : prevPart.quantityInStock;
-    const threshold = payload.minReorderThreshold !== undefined ? payload.minReorderThreshold : prevPart.minReorderThreshold;
+    const quantity = payload.quantityInStock !== undefined ? payload.quantityInStock : part.quantityInStock;
+    const threshold = payload.minReorderThreshold !== undefined ? payload.minReorderThreshold : part.minReorderThreshold;
     
     if (quantity < 0 || threshold < 0) {
       return res.status(400).json({ error: "Inventory quantities cannot be negative." });
@@ -85,20 +88,24 @@ exports.updatePart = async (req, res) => {
 
     if (quantity > threshold) {
       payload.reorderStatus = 'ok';
-    } else if (prevPart.reorderStatus === 'ok') {
+    } else if (part.reorderStatus === 'ok') {
       payload.reorderStatus = 'low-stock';
     }
 
-    const part = await SparePart.findByIdAndUpdate(req.params.id, payload, { new: true });
+    // Apply updates
+    part.set(payload);
+    
+    // Save (will trigger version check because of mongoose-update-if-current)
+    await part.save();
 
     // Log Activity if stock count changed
-    if (prevPart.quantityInStock !== part.quantityInStock) {
+    if (prevStock !== part.quantityInStock) {
       await logActivity({
         type: "inventory_updated",
         title: "Spare Part Stock Updated",
-        description: `Stock level for "${part.name}" changed from ${prevPart.quantityInStock} to ${part.quantityInStock}`,
+        description: `Stock level for "${part.name}" changed from ${prevStock} to ${part.quantityInStock}`,
         userName: req.user?.name || "System",
-        metadata: { from: prevPart.quantityInStock, to: part.quantityInStock, sku: part.sku },
+        metadata: { from: prevStock, to: part.quantityInStock, sku: part.sku },
         entityType: "inventory",
         entityId: String(part._id)
       });
@@ -106,6 +113,12 @@ exports.updatePart = async (req, res) => {
 
     res.json(part);
   } catch (error) {
+    if (error.name === 'VersionError') {
+      return res.status(409).json({ 
+        error: "Concurrency Conflict: This spare part was modified by another user. Please refresh and try again.",
+        code: "VERSION_ERROR"
+      });
+    }
     res.status(400).json({ error: error.message });
   }
 };

--- a/server/models/SparePart.js
+++ b/server/models/SparePart.js
@@ -1,5 +1,6 @@
 const { mongoose } = require('../config/database');
 const { Schema } = mongoose;
+const updateIfCurrentPlugin = require('mongoose-update-if-current').updateIfCurrentPlugin;
 
 const SparePartSchema = new Schema({
   name: { type: String, required: true },
@@ -14,6 +15,8 @@ const SparePartSchema = new Schema({
   location: { type: String }, // shelf location e.g. Shelf A-4
   reorderStatus: { type: String, enum: ['ok', 'low-stock', 'reordered'], default: 'ok' }
 }, { timestamps: true });
+
+SparePartSchema.plugin(updateIfCurrentPlugin);
 
 SparePartSchema.set('toObject', { virtuals: true });
 SparePartSchema.set('toJSON', { virtuals: true });


### PR DESCRIPTION
## **Title:** fix: Race Condition in Spare Part Inventory Decrementing using OCC

## Closes #312 

### **Description:**
This PR resolves a critical read-modify-write race condition within the inventory management module. Previously, concurrent edits to a single `SparePart` by multiple administrators would blindly overwrite each other, leading to data loss (e.g., negative stock adjustments or lost receiving shipments). The system now guarantees data integrity using Optimistic Concurrency Control (OCC).

### **Changes Proposed:**
1. **Database Schema Enforcements:**
   - Integrated the `mongoose-update-if-current` plugin into the `SparePart` schema.
   - Enforced strict version key (`__v`) checking on all document saves to guarantee atomic integrity.

2. **Backend Concurrency Handling:**
   - Refactored `inventoryController.js` (`updatePart` logic) to fetch the document (`findById`), explicitly set values (`set()`), and safely execute `.save()` rather than using the bypass method `findByIdAndUpdate`.
   - Added `try/catch` handlers to specifically intercept `VersionError` exceptions when concurrent modifications are detected.

3. **Frontend Resolution & UX:**
   - Updated the global Axios interceptor (`client/src/services/api.ts`) to gracefully intercept HTTP `409 Conflict` responses.
   - Replaced generic crash logs with a user-friendly Toast notification: *"Concurrency Conflict: This record was modified by another user. Please refresh and try again."*