### PR TITLE
fix: Webhook Delivery Memory Leak during IoT Storms

### DIFF
--- a/server/jobs/webhookDispatcher.js
+++ b/server/jobs/webhookDispatcher.js
@@ -1,8 +1,20 @@
 const axios = require('axios');
+const http = require('http');
+const https = require('https');
 const { Worker } = require('bullmq');
 const IORedis = require('ioredis');
 const WebhookEvent = require('../models/WebhookEvent');
 const circuitBreaker = require('../utils/circuitBreaker');
+
+// Configure keep-alive agents to prevent Socket Exhaustion during High-Volume Event Storms
+const httpAgent = new http.Agent({ keepAlive: true, maxSockets: 100 });
+const httpsAgent = new https.Agent({ keepAlive: true, maxSockets: 100 });
+
+const keepAliveAxios = axios.create({
+  httpAgent,
+  httpsAgent,
+  timeout: 10000
+});
 
 const connection = new IORedis(process.env.REDIS_URL || 'redis://localhost:6379', {
   maxRetriesPerRequest: null
@@ -45,7 +57,7 @@ class WebhookDispatcher {
 
       // 4. Attempt the HTTP request
       try {
-        const response = await axios.post(url, formattedPayload, { timeout: 10000 });
+        const response = await keepAliveAxios.post(url, formattedPayload);
         
         // Success
         await circuitBreaker.recordSuccess(url);

--- a/server/services/webhookService.js
+++ b/server/services/webhookService.js
@@ -54,7 +54,8 @@ exports.queueWebhookEvent = async (eventName, payload) => {
           type: 'exponential',
           delay: 1000 // 1s, 2s, 4s, 8s, 16s
         },
-        removeOnComplete: true
+        removeOnComplete: true,
+        removeOnFail: true
       });
     }
 

--- a/server/tests/webhookController.test.js
+++ b/server/tests/webhookController.test.js
@@ -1,5 +1,5 @@
 const webhookController = require('../controllers/webhookController');
-const { Webhook } = require('../models');
+const { Webhook, WebhookEvent } = require('../models');
 const axios = require('axios');
 
 jest.mock('../models', () => ({
@@ -8,6 +8,9 @@ jest.mock('../models', () => ({
     create: jest.fn(),
     findByIdAndUpdate: jest.fn(),
     findByIdAndDelete: jest.fn()
+  },
+  WebhookEvent: {
+    create: jest.fn()
   }
 }));
 jest.mock('axios');
@@ -121,15 +124,16 @@ describe('Webhook Controller', () => {
   });
 
   describe('testWebhook', () => {
-    it('should send a test payload via axios', async () => {
+    it('should queue a test payload via WebhookEvent', async () => {
       req.body = { url: 'http://test.com', provider: 'Slack' };
-      axios.post.mockResolvedValue({ status: 200 });
+      const newWebhookEvent = { _id: 'event-1' };
+      WebhookEvent.create.mockResolvedValue(newWebhookEvent);
 
       await webhookController.testWebhook(req, res);
 
-      expect(axios.post).toHaveBeenCalled();
+      expect(WebhookEvent.create).toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith({ success: true, message: 'Test webhook sent successfully' });
+      expect(res.json).toHaveBeenCalledWith({ success: true, message: 'Test webhook queued successfully via dispatcher', data: newWebhookEvent });
     });
 
     it('should return 400 if url or provider is missing', async () => {


### PR DESCRIPTION
## Title
fix: Webhook Delivery Memory Leak during IoT Storms

## Closes #315 

## Description
This PR resolves critical memory leaks (both in Redis and Node.js) that occurred during high-volume IoT event storms when external webhook targets failed or severely rate-limited requests.

### Key Changes
**Backend Redis Optimization:**
- Added `removeOnFail: true` to the BullMQ queue `add` configuration in `webhookService.js`.
  - **Reason:** BullMQ retains all failed jobs in Redis indefinitely by default. During an event storm, failing webhooks piled up, causing Redis OOM errors. Because we already log all failed webhooks in our persistent MongoDB Dead-Letter Queue (`WebhookEvent`), keeping them in Redis was redundant.

**Node.js Socket Leak Fix:**
- Instantiated shared `http.Agent` and `https.Agent` pools with `keepAlive: true` and `maxSockets: 100` in `webhookDispatcher.js`.
- Replaced the default stateless `axios` calls with a dedicated `keepAliveAxios` instance that enforces these connection pools.
  - **Reason:** Previously, `axios` negotiated a new TCP handshake and consumed a new ephemeral socket for every outbound webhook request. Under a storm, this exhausted the OS's ephemeral ports (`TIME_WAIT` pileup) and bloated Node.js garbage collection with orphaned sockets. Reusing connections completely eliminates this memory bloat.

**Test Integrity:**
- Fixed failing unit tests in `webhookController.test.js` where legacy mocks were attempting to trap `axios.post` instead of the modern `WebhookEvent.create` dispatcher queue method.

## Testing Instructions
1. Run `npm test` inside the `/server` directory to ensure webhook test integrity passes.
2. In a staging environment, manually trigger thousands of webhook events targeted at a dead URL; monitor Redis memory and verify it stays flat rather than accumulating failed objects.
3. Observe the `WebhookEvent` DLQ via MongoDB to confirm failed events are still accurately logged.
