### PR TITLE
fix(equipment): prevent equipment deletion 

### DIFF
--- a/server/controllers/equipmentController.js
+++ b/server/controllers/equipmentController.js
@@ -249,6 +249,20 @@ exports.updateEquipment = asyncHandler(async (req, res, next) => {
 
 // Delete equipment
 exports.deleteEquipment = asyncHandler(async (req, res, next) => {
+  // Check for active maintenance requests
+  const activeRequests = await MaintenanceRequest.find({
+    equipmentId: req.params.id,
+    stage: { $nin: ['repaired', 'scrap'] }
+  });
+
+  if (activeRequests.length > 0) {
+    throw new ErrorHandler(
+      "Cannot delete equipment with active maintenance tickets. Please close or reassign them first.",
+      ERROR_TYPES.VALIDATION_ERROR,
+      400
+    );
+  }
+
   const equipment = await Equipment.findByIdAndDelete(req.params.id);
   if (!equipment) {
     throw new ErrorHandler("Equipment not found", ERROR_TYPES.NOT_FOUND_ERROR);
@@ -262,7 +276,7 @@ exports.deleteEquipment = asyncHandler(async (req, res, next) => {
     userName: req.user?.name || ""
   });
 
-  // Cascade delete all maintenance requests associated with this equipment
+  // Cascade delete all CLOSED/REPAIRED maintenance requests associated with this equipment
   await MaintenanceRequest.deleteMany({ equipmentId: req.params.id });
 
   res.status(200).json({


### PR DESCRIPTION
Closes #322 

##  Bug Fix: "Zombie Tickets" Crash Routing Engine on Equipment Deletion
This PR resolves a critical data-corruption issue where planners could delete Equipment records that still had active maintenance tickets linked to them. This caused those tickets to become "Zombies" with null equipment pointers, instantly crashing the `smartAssignInternal` auto-routing engine and causing fatal React runtime errors on the Kanban board.

### What was changed:
* **Pre-Deletion Safety Check (`equipmentController.js`)**: Updated the `deleteEquipment` controller to query for any existing `MaintenanceRequest` documents linked to the requested `equipmentId` where the stage is NOT `repaired` or `scrap`.
* **Validation Blocking**: If any active/open tickets are found, the system explicitly blocks the deletion and throws an HTTP 400 Validation Error: *"Cannot delete equipment with active maintenance tickets. Please close or reassign them first."*
* **Safe Cascading**: Only if the equipment has zero active tickets will the deletion proceed, safely cascade-deleting any historical/closed tickets to keep the database clean.

###  Verification
* Verified that attempting to delete a piece of equipment with a ticket in the `new` or `in-progress` stage correctly aborts and shows the user the warning message.
* Verified that deleting equipment with only `repaired` historical tickets successfully removes the equipment and cascade deletes the old ticket data without breaking the Kanban board.