### PR TITLE
fix(#325): resolve negative inventory race condition

### DIFF
--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -293,14 +293,20 @@ exports.createRequest = async (req, res) => {
         for (const reqPart of payload.requiredParts) {
           const partDoc = await SparePart.findById(reqPart.partId).session(session);
           if (partDoc) {
-             const availableStock = partDoc.quantityInStock - partDoc.quantityReserved;
-             if (availableStock < reqPart.quantityNeeded) {
+             estimatedPartsCost += (partDoc.unitCost || 0) * (reqPart.quantityNeeded || 1);
+             const updatedPart = await SparePart.findOneAndUpdate(
+               { 
+                 _id: reqPart.partId,
+                 $expr: { $gte: [{ $subtract: ["$quantityInStock", "$quantityReserved"] }, reqPart.quantityNeeded] }
+               },
+               {
+                 $inc: { quantityReserved: reqPart.quantityNeeded }
+               },
+               { session, new: true }
+             );
+             if (!updatedPart) {
                isBlocked = true;
              }
-             estimatedPartsCost += (partDoc.unitCost || 0) * (reqPart.quantityNeeded || 1);
-             await SparePart.findByIdAndUpdate(reqPart.partId, {
-               $inc: { quantityReserved: reqPart.quantityNeeded }
-             }, { session });
           }
         }
       }


### PR DESCRIPTION
## 📌 Pull Request Title

fix: resolve negative inventory race condition (#325)

---

## 🚀 Description

This PR fixes the critical "Negative Inventory" race condition (Issue #325). Previously, createRequest calculated availableStock and updated quantityReserved in two separate operations, allowing multiple concurrent requests to slip through and drive inventory negative when competing for the same final spare part.

---

## 🔗 Related Issue

Closes #325 

---

## 📝 Changes Made

- Refactored the quantityReserved increment inside server/controllers/requestController.js (createRequest).
- Replaced the non-atomic Javascript validation with a fully atomic MongoDB findOneAndUpdate operation.
- Utilized $expr with $subtract to evaluate quantityInStock - quantityReserved >= quantityNeeded concurrently at the database level, preventing any race conditions from bypassing the check.
- If the atomic update fails (meaning stock ran out a microsecond prior), the ticket safely correctly marks isBlocked = true.

---

## 🧪 Testing Performed

- [x] Tested locally
- [x] Templates render correctly on GitHub

---

## 🏷️ NSoC'26 Information

- **Level:** Level 3
- **Points:** 10

---

## ✅ Checklist

- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] This PR does not break existing functionality
- [x] I have added necessary documentation

---

## ⚠️ Important

- PR without issue assignment will be **rejected**
- Missing `NSoC'26` tag will be **requested for update**

---

Thank you for your contribution! 🎉