### PR TITLE
fix(#329): implement dynamic SLA timers to prevent stale breaches

### DIFF
--- a/client/src/pages/KanbanBoard.tsx
+++ b/client/src/pages/KanbanBoard.tsx
@@ -110,13 +110,30 @@ const RequestCard: React.FC<
       }),
     }));
 
+  const [currentTime, setCurrentTime] = useState(Date.now());
+
+  useEffect(() => {
+    if (request.stage === "repaired" || request.stage === "scrap") return;
+    const interval = setInterval(() => {
+      setCurrentTime(Date.now());
+    }, 60000); // Check every minute
+    return () => clearInterval(interval);
+  }, [request.stage]);
+
+  const isDynamicallyBreached = () => {
+    if (request.slaBreached) return true;
+    if (request.stage === "repaired" || request.stage === "scrap") return false;
+    if (request.slaDeadline && currentTime > new Date(request.slaDeadline).getTime()) return true;
+    return false;
+  };
+
   const isOverdue = (
     date?: string,
     stage?: string
   ) => {
     if (!date) return false;
 
-    const today = new Date();
+    const today = new Date(currentTime);
 
     const due = new Date(date);
 
@@ -163,7 +180,7 @@ const RequestCard: React.FC<
           : 1,
       }}
       className={`kanban-card bg-white dark:bg-gray-800 p-4 rounded-lg shadow-sm dark:shadow-none border-2 mb-3 cursor-pointer ${
-        request.slaBreached 
+        isDynamicallyBreached() 
           ? "border-red-500 shadow-red-500/20"
           : (request.slaBreachProbability && request.slaBreachProbability >= 85 && request.stage !== "repaired" && request.stage !== "scrap")
           ? "border-orange-500 shadow-orange-500/20 bg-orange-50 dark:bg-orange-900/10 animate-pulse-border"


### PR DESCRIPTION
## 📌 Pull Request Title

implement dynamic SLA timers to prevent stale breaches

---

## 🚀 Description

This PR addresses Issue #329, resolving the critical bug where SLA breach visuals on the Kanban board would become stale and fail to update if the planner left the browser tab open without refreshing.

---

## 🔗 Related Issue

Closes #329 

---

## 📝 Changes Made

- Dynamic Time State: Added a currentTime React state to the RequestCard component.
- Interval Trigger: Implemented a useEffect hook that runs a setInterval to update currentTime every 60 seconds. This is deliberately disabled for inactive stages (repaired, scrap) to ensure memory and CPU are preserved for massive Kanban boards.
- Dynamic Breach Calculation: Created an isDynamicallyBreached() helper function. It falls back to the backend slaBreached boolean but also actively checks if currentTime > slaDeadline.
- Overdue State Fix: Updated the existing isOverdue utility to reference the currentTime state instead of a static new Date(), ensuring that overdue visual states also update automatically when the clock strikes midnight.

---

## 🧪 Testing Performed

- [x] Tested locally
- [x] Templates render correctly on GitHub

---

## 🏷️ NSoC'26 Information

- **Level:** Level 3
- **Points:** 10

---

## ✅ Checklist

- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] This PR does not break existing functionality
- [x] I have added necessary documentation

---

## ⚠️ Important

- PR without issue assignment will be **rejected**
- Missing `NSoC'26` tag will be **requested for update**

---

Thank you for your contribution! 🎉