### PR TITLE
Fix race condition in inventory allocation and update tests

### DIFF
--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -46,6 +46,7 @@ const calculateDowntimeCost = async (requestCreatedAt, completedDate, equipmentI
   totalDowntimeCost = downtimeDurationHours * hourlyDowntimeCost;
 
   return { downtimeDurationHours, totalDowntimeCost };
+};
 const checkCertifications = async (assignedToId, requiredSkills, session = null) => {
   if (!assignedToId || !requiredSkills || requiredSkills.length === 0) return true;
   const tech = await TeamMember.findById(assignedToId).session(session);
@@ -54,53 +55,50 @@ const checkCertifications = async (assignedToId, requiredSkills, session = null)
   return requiredSkills.every(skill => techCerts.includes(skill));
 };
 
-const decrementInventory = async (io, partsUsed) => {
+const decrementInventory = async (io, partsUsed, session) => {
   if (!partsUsed || !Array.isArray(partsUsed) || partsUsed.length === 0) return;
   for (const item of partsUsed) {
     const partId = item.partId?._id || item.partId;
     if (!partId) continue;
-    try {
-      // Atomic decrement prevents concurrency data loss and prevents negative stock
-      const updatedPart = await SparePart.findOneAndUpdate(
-        { _id: partId, quantityInStock: { $gte: item.quantityUsed } },
-        { $inc: { quantityInStock: -item.quantityUsed } },
-        { new: true }
-      );
+    
+    // Atomic decrement prevents concurrency data loss and prevents negative stock
+    const updatedPart = await SparePart.findOneAndUpdate(
+      { _id: partId, quantityInStock: { $gte: item.quantityUsed } },
+      { $inc: { quantityInStock: -item.quantityUsed } },
+      { new: true, session }
+    );
 
-      if (updatedPart) {
-        if (updatedPart.quantityInStock <= updatedPart.minReorderThreshold) {
-          if (updatedPart.reorderStatus === 'ok') {
-            const finalPart = await SparePart.findByIdAndUpdate(
-              partId, 
-              { reorderStatus: 'low-stock' }, 
-              { new: true }
-            );
-            await NotificationService.notifyLowStock(io, finalPart);
-          }
-        } else if (updatedPart.reorderStatus !== 'ok') {
-           await SparePart.findByIdAndUpdate(partId, { reorderStatus: 'ok' });
+    if (!updatedPart) {
+      throw new Error(`Insufficient stock for part allocation (ID: ${partId})`);
+    }
+
+    if (updatedPart.quantityInStock <= updatedPart.minReorderThreshold) {
+      if (updatedPart.reorderStatus === 'ok') {
+        const finalPart = await SparePart.findByIdAndUpdate(
+          partId, 
+          { reorderStatus: 'low-stock' }, 
+          { new: true, session }
+        );
+        if (io) {
+          NotificationService.notifyLowStock(io, finalPart).catch(err => console.error(err));
         }
       }
-    } catch (err) {
-      console.error(`Failed to decrement inventory for part ${partId}:`, err);
+    } else if (updatedPart.reorderStatus !== 'ok') {
+       await SparePart.findByIdAndUpdate(partId, { reorderStatus: 'ok' }, { session });
     }
   }
 };
 
-const releaseReservations = async (requiredParts) => {
+const releaseReservations = async (requiredParts, session) => {
   if (!requiredParts || !Array.isArray(requiredParts) || requiredParts.length === 0) return;
   for (const item of requiredParts) {
     const partId = item.partId?._id || item.partId;
     if (!partId) continue;
-    try {
-      await SparePart.findByIdAndUpdate(
-        partId,
-        { $inc: { quantityReserved: -item.quantityNeeded } },
-        { new: true }
-      );
-    } catch (err) {
-      console.error(`Failed to release reservation for part ${partId}:`, err);
-    }
+    await SparePart.findByIdAndUpdate(
+      partId,
+      { $inc: { quantityReserved: -item.quantityNeeded } },
+      { new: true, session }
+    );
   }
 };
 
@@ -634,11 +632,27 @@ exports.updateRequest = async (req, res) => {
         }
       }
 
-      return await MaintenanceRequest.findByIdAndUpdate(
+      const isCompleted = prevStage === "repaired" || prevStage === "scrap";
+      const nowCompleted = payload.stage === "repaired" || payload.stage === "scrap";
+      const shouldProcessCompletion = payload.stage && nowCompleted && !isCompleted && !prevRequest.completionProcessed;
+      
+      if (shouldProcessCompletion) {
+        payload.completionProcessed = true;
+      }
+
+      const updatedReq = await MaintenanceRequest.findByIdAndUpdate(
         req.params.id,
         payload,
         { new: true, session }
       ).populate("equipment").populate("createdBy", "name email");
+
+      if (shouldProcessCompletion) {
+        const io = req.app.get("socketio");
+        await decrementInventory(io, updatedReq.partsUsed, session);
+        await releaseReservations(updatedReq.requiredParts, session);
+      }
+
+      return updatedReq;
     });
 
     // Notify requester if stage changed
@@ -690,12 +704,6 @@ exports.updateRequest = async (req, res) => {
     const isCompleted = prevStage === "repaired" || prevStage === "scrap";
     const nowCompleted = request.stage === "repaired" || request.stage === "scrap";
     const shouldProcessCompletion = request.stage && nowCompleted && !isCompleted && !request.completionProcessed;
-    if (shouldProcessCompletion) {
-      const io = req.app.get("socketio");
-      await decrementInventory(io, request.partsUsed);
-      await releaseReservations(request.requiredParts);
-      await MaintenanceRequest.findByIdAndUpdate(req.params.id, { completionProcessed: true });
-    }
 
     const updatedRequest = await MaintenanceRequest.findById(req.params.id)
       .populate("equipment")
@@ -840,47 +848,51 @@ exports.updateRequestStage = async (req, res) => {
       }
     }
 
+    const isCompleted = prevStage === "repaired" || prevStage === "scrap";
+    const nowCompleted = stage === "repaired" || stage === "scrap";
+    const shouldProcessCompletion = nowCompleted && !isCompleted && !request.completionProcessed;
+
     const updateData = { stage };
     if (partsCost !== undefined) updateData.partsCost = partsCost;
     if (laborCost !== undefined) updateData.laborCost = laborCost;
 
-    await MaintenanceRequest.findByIdAndUpdate(req.params.id, updateData);
+    if (shouldProcessCompletion) {
+      updateData.completionProcessed = true;
+    }
 
     if (stage === "repaired" || stage === "scrap") {
-      const completedDate = new Date();
+      updateData.completedDate = new Date();
       const { downtimeDurationHours, totalDowntimeCost } = await calculateDowntimeCost(
-        request.createdAt, completedDate, request.equipmentId
+        request.createdAt, updateData.completedDate, request.equipmentId
       );
+      updateData.downtimeDurationHours = downtimeDurationHours;
+      updateData.totalDowntimeCost = totalDowntimeCost;
+    }
 
-      await MaintenanceRequest.findByIdAndUpdate(req.params.id, {
-        completedDate,
-        downtimeDurationHours,
-        totalDowntimeCost
-      });
+    await withTransactionFallback(async (session) => {
+      await MaintenanceRequest.findByIdAndUpdate(req.params.id, updateData, { session });
 
-      if (request.equipmentId) {
-        const newStatus = stage === "scrap" ? "scrapped" : "active";
-        await Equipment.findByIdAndUpdate(request.equipmentId, {
-          $set: { status: newStatus },
-          $push: { history: {
-            eventType: stage === "scrap" ? 'SCRAPPED' : 'REPAIR_COMPLETED',
-            description: `Request stage updated to ${stage}. Status changed to ${newStatus}.`,
-            userId: req.user?._id,
-            userName: req.user?.name || "System"
-          }}
-        });
+      if (stage === "repaired" || stage === "scrap") {
+        if (request.equipmentId) {
+          const newStatus = stage === "scrap" ? "scrapped" : "active";
+          await Equipment.findByIdAndUpdate(request.equipmentId, {
+            $set: { status: newStatus },
+            $push: { history: {
+              eventType: stage === "scrap" ? 'SCRAPPED' : 'REPAIR_COMPLETED',
+              description: `Request stage updated to ${stage}. Status changed to ${newStatus}.`,
+              userId: req.user?._id,
+              userName: req.user?.name || "System"
+            }}
+          }, { session });
+        }
       }
-    }
 
-    const isCompleted = prevStage === "repaired" || prevStage === "scrap";
-    const nowCompleted = stage === "repaired" || stage === "scrap";
-    const shouldProcessCompletion = nowCompleted && !isCompleted && !request.completionProcessed;
-    if (shouldProcessCompletion) {
-      const io = req.app.get("socketio");
-      await decrementInventory(io, request.partsUsed);
-      await releaseReservations(request.requiredParts);
-      await MaintenanceRequest.findByIdAndUpdate(req.params.id, { completionProcessed: true });
-    }
+      if (shouldProcessCompletion) {
+        const io = req.app.get("socketio");
+        await decrementInventory(io, request.partsUsed, session);
+        await releaseReservations(request.requiredParts, session);
+      }
+    });
 
     const updatedRequest = await MaintenanceRequest.findById(req.params.id)
       .populate("equipment")

--- a/server/models/MaintenanceRequest.js
+++ b/server/models/MaintenanceRequest.js
@@ -93,7 +93,7 @@ const MaintenanceRequestSchema = new Schema({
     message: { type: String },
     magicToken: { type: String, select: false },
     tokenExpiresAt: { type: Date }
-  }
+  },
   rootCause: { type: String }, // Used by the RCA logic tree wizard
   rcaNodeId: { type: Schema.Types.ObjectId, ref: 'DiagnosticNode' } // Final leaf node of the RCA tree
 }, { timestamps: true });

--- a/server/tests/inventoryRace.test.js
+++ b/server/tests/inventoryRace.test.js
@@ -1,0 +1,137 @@
+const mongoose = require("mongoose");
+const request = require("supertest");
+const app = require("../index");
+const MaintenanceRequest = require("../models/MaintenanceRequest");
+const SparePart = require("../models/SparePart");
+const User = require("../models/User");
+const bcrypt = require("bcryptjs");
+const { MongoMemoryReplSet } = require("mongodb-memory-server");
+
+jest.setTimeout(30000);
+
+describe("Race Condition: Spare Parts Inventory Allocation", () => {
+  let adminUser, adminToken;
+  let partDoc;
+  let requestIds = [];
+  let mongoServer;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
+    const uri = mongoServer.getUri();
+    
+    // Disconnect if already connected (e.g. from app require)
+    if (mongoose.connection.readyState !== 0) {
+      await mongoose.disconnect();
+    }
+    
+    await mongoose.connect(uri);
+
+    const hashedPassword = await bcrypt.hash("password123", 10);
+
+    // Create an Admin user for auth
+    adminUser = await User.create({
+      name: "Admin User",
+      email: "admin_race@gearguard.local",
+      password: hashedPassword,
+      role: "Admin",
+      department: "Maintenance"
+    });
+    
+    const loginRes = await request(app)
+      .post("/api/auth/login")
+      .set("User-Agent", "supertest/1.0.0")
+      .send({ email: "admin_race@gearguard.local", password: "password123" });
+    
+    adminToken = loginRes.body.token;
+  });
+
+  afterAll(async () => {
+    await MaintenanceRequest.deleteMany({ _id: { $in: requestIds } });
+    await SparePart.findByIdAndDelete(partDoc._id);
+    await User.findByIdAndDelete(adminUser._id);
+    await mongoose.disconnect();
+    if (mongoServer) {
+      await mongoServer.stop();
+    }
+  });
+
+  beforeEach(async () => {
+    // Reset or create a spare part with EXACTLY 2 in stock
+    if (partDoc) {
+      await SparePart.findByIdAndDelete(partDoc._id);
+    }
+    partDoc = await SparePart.create({
+      name: "Race Condition Widget",
+      sku: "RC-WIDGET-" + Date.now(),
+      quantityInStock: 2,
+      minReorderThreshold: 1,
+      unitCost: 50
+    });
+
+    // Create 3 maintenance requests, each requiring 1 of the above part
+    for (let i = 0; i < 3; i++) {
+      const newReq = await MaintenanceRequest.create({
+        requestNumber: `REQ-RACE-${i}-${Date.now()}`,
+        subject: `Race Test Request ${i}`,
+        description: "Testing concurrent allocation",
+        priority: "medium",
+        stage: "in-progress",
+        createdBy: adminUser._id,
+        partsUsed: [{ partId: partDoc._id, quantityUsed: 1 }]
+      });
+      requestIds.push(newReq._id);
+    }
+  });
+
+  afterEach(async () => {
+    await MaintenanceRequest.deleteMany({ _id: { $in: requestIds } });
+    requestIds = [];
+  });
+
+  it("should prevent stock from dropping below zero under highly concurrent completions", async () => {
+    // We have 3 requests, but only 2 widgets in stock.
+    // Concurrently try to mark all 3 as 'repaired' via updateRequestStage.
+    const concurrentRequests = requestIds.map(reqId => {
+      return request(app)
+        .patch(`/api/requests/${reqId}/stage`)
+        .set("Authorization", `Bearer ${adminToken}`)
+        .set("User-Agent", "supertest/1.0.0")
+        .send({ stage: "repaired" });
+    });
+
+    const responses = await Promise.all(concurrentRequests);
+
+    let successCount = 0;
+    let failCount = 0;
+
+    responses.forEach(res => {
+      if (res.status === 200) {
+        successCount++;
+      } else {
+        failCount++;
+        // The error should match what decrementInventory throws
+        expect(res.body.error).toContain("Insufficient stock for part allocation");
+      }
+    });
+
+    // Exactly 2 should succeed, 1 should fail
+    expect(successCount).toBe(2);
+    expect(failCount).toBe(1);
+
+    // Verify inventory level is exactly 0, not -1
+    const updatedPart = await SparePart.findById(partDoc._id);
+    expect(updatedPart.quantityInStock).toBe(0);
+
+    // Verify the failed request did NOT get marked as 'repaired'
+    const failedRequestRes = responses.find(r => r.status !== 200);
+    const failedReqIdUrl = failedRequestRes.req.path;
+    const failedReqIdMatch = failedReqIdUrl.match(/\/api\/requests\/(.+)\/stage/);
+    if (failedReqIdMatch) {
+      const failedReqId = failedReqIdMatch[1];
+      const failedReqDoc = await MaintenanceRequest.findById(failedReqId);
+      expect(failedReqDoc.stage).not.toBe("repaired");
+      expect(failedReqDoc.stage).toBe("in-progress");
+      expect(failedReqDoc.completionProcessed).toBeFalsy();
+    }
+  });
+});


### PR DESCRIPTION
**Title:** Fix race condition in spare parts inventory allocation

## Closes #333 

**Description:**

### What does this PR do?
Resolves a concurrency issue where simultaneous work order completions could bypass available stock limits and drive inventory below zero. 

### Why is this needed?
When multiple technicians complete maintenance requests simultaneously that require the same spare part, the inventory check and decrement were not atomic. If the initial stock check passed for all concurrent requests, they would all successfully allocate the part, potentially resulting in negative inventory quantities. 

### How was it fixed?
- **Atomic Transactions**: Refactored `updateRequest` and `updateRequestStage` in `server/controllers/requestController.js` to ensure the core logic runs atomically using `withTransactionFallback`.
- **Session Propagated**: Updated `decrementInventory` and `releaseReservations` to properly consume the active database `session` during transactions.
- **Strict Validation**: The code now correctly throws an `Insufficient stock for part allocation` error when the required stock threshold is crossed during concurrent requests, rolling back the entire stage change.

### Testing & Verification
- Added a new integration test (`server/tests/inventoryRace.test.js`) to simulate highly concurrent completions.
- Updated the test environment to utilize `MongoMemoryReplSet` for full local transaction support.
- **Verification Details:** Simulated 3 concurrent requests competing for 2 items in stock. The test properly prevents the 3rd request from consuming stock and dropping the inventory to -1, leaving the 3rd request's stage as `in-progress`.