### PR TITLE
Feat/356 nfc scanning

### DIFF
--- a/client/src/components/AudioDiagnosticLogger.tsx
+++ b/client/src/components/AudioDiagnosticLogger.tsx
@@ -1,0 +1,163 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Mic, Square, Trash2, PlusCircle, Activity } from 'lucide-react';
+import Button from './Button';
+
+interface AudioDiagnosticLoggerProps {
+  onAudioRecorded: (file: File) => void;
+}
+
+const AudioDiagnosticLogger: React.FC<AudioDiagnosticLoggerProps> = ({ onAudioRecorded }) => {
+  const [isRecording, setIsRecording] = useState(false);
+  const [recordingDuration, setRecordingDuration] = useState(0);
+  const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioStreamRef = useRef<MediaStream | null>(null);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+      if (audioStreamRef.current) {
+        audioStreamRef.current.getTracks().forEach(track => track.stop());
+      }
+      if (audioUrl) {
+        URL.revokeObjectURL(audioUrl);
+      }
+    };
+  }, [audioUrl]);
+
+  const startRecording = async () => {
+    try {
+      discardRecording(); // Clean slate
+
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      audioStreamRef.current = stream;
+
+      const mediaRecorder = new MediaRecorder(stream);
+      mediaRecorderRef.current = mediaRecorder;
+
+      const chunks: BlobPart[] = [];
+      mediaRecorder.ondataavailable = (e) => {
+        if (e.data.size > 0) {
+          chunks.push(e.data);
+        }
+      };
+
+      mediaRecorder.onstop = () => {
+        const blob = new Blob(chunks, { type: 'audio/webm' });
+        const url = URL.createObjectURL(blob);
+        setAudioBlob(blob);
+        setAudioUrl(url);
+      };
+
+      mediaRecorder.start();
+      setIsRecording(true);
+      setRecordingDuration(0);
+
+      timerRef.current = setInterval(() => {
+        setRecordingDuration(prev => prev + 1);
+      }, 1000);
+    } catch (error) {
+      console.error('Failed to start recording:', error);
+      alert('Microphone access denied or unavailable.');
+    }
+  };
+
+  const stopRecording = () => {
+    if (mediaRecorderRef.current && isRecording) {
+      mediaRecorderRef.current.stop();
+      setIsRecording(false);
+      if (timerRef.current) clearInterval(timerRef.current);
+      if (audioStreamRef.current) {
+        audioStreamRef.current.getTracks().forEach(track => track.stop());
+      }
+    }
+  };
+
+  const discardRecording = () => {
+    setAudioBlob(null);
+    if (audioUrl) {
+      URL.revokeObjectURL(audioUrl);
+      setAudioUrl(null);
+    }
+    setRecordingDuration(0);
+  };
+
+  const handleAttach = () => {
+    if (audioBlob) {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const file = new File([audioBlob], `diagnostic_audio_${timestamp}.webm`, { type: 'audio/webm' });
+      onAudioRecorded(file);
+      discardRecording();
+    }
+  };
+
+  return (
+    <div className="w-full bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-200 flex items-center">
+          <Activity className="w-4 h-4 mr-2 text-blue-500" />
+          Diagnostic Audio Logger
+        </h4>
+      </div>
+
+      {isRecording ? (
+        <div className="flex items-center justify-between gap-3 px-4 py-3 border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-950/20 rounded-lg animate-pulse">
+          <div className="flex items-center gap-3">
+            <span className="relative flex h-3 w-3">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75"></span>
+              <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500"></span>
+            </span>
+            <span className="text-sm font-semibold text-red-600 dark:text-red-400 font-mono">
+              Recording... {Math.floor(recordingDuration / 60)}:{(recordingDuration % 60).toString().padStart(2, '0')}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={stopRecording}
+            className="flex items-center px-3 py-1.5 bg-red-600 text-white text-xs font-bold rounded-md hover:bg-red-700 transition-colors shadow-sm"
+          >
+            <Square className="w-3 h-3 mr-1 fill-current" />
+            Stop
+          </button>
+        </div>
+      ) : audioUrl ? (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-3 p-3 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg">
+            <audio controls src={audioUrl} className="h-8 w-full max-w-[200px]" />
+            <div className="flex space-x-2">
+              <button
+                type="button"
+                onClick={discardRecording}
+                className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
+                title="Discard"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+          <Button type="button" variant="primary" onClick={handleAttach} className="w-full flex items-center justify-center py-2 text-sm">
+            <PlusCircle className="w-4 h-4 mr-2" />
+            Attach to Request
+          </Button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={startRecording}
+          className="w-full flex flex-col items-center justify-center p-4 border-2 border-dashed border-blue-300 dark:border-blue-800 rounded-lg bg-blue-50/50 dark:bg-blue-900/10 hover:bg-blue-50 dark:hover:bg-blue-900/30 text-blue-600 dark:text-blue-400 transition-colors cursor-pointer group"
+        >
+          <div className="p-3 bg-blue-100 dark:bg-blue-900/50 rounded-full mb-2 group-hover:scale-110 transition-transform">
+            <Mic className="w-6 h-6" />
+          </div>
+          <span className="text-sm font-medium">Record Machine Audio</span>
+          <span className="text-xs opacity-75 mt-1 text-center">Capture unusual sounds for remote diagnosis (Max 30s recommended)</span>
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default AudioDiagnosticLogger;

--- a/client/src/components/ImageAnnotationModal.tsx
+++ b/client/src/components/ImageAnnotationModal.tsx
@@ -1,0 +1,213 @@
+import React, { useRef, useEffect, useState } from 'react';
+import Modal from './Modal';
+import Button from './Button';
+import { Undo, Check, X } from 'lucide-react';
+
+interface ImageAnnotationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  file: File | null;
+  onSave: (annotatedFile: File) => void;
+}
+
+const ImageAnnotationModal: React.FC<ImageAnnotationModalProps> = ({
+  isOpen,
+  onClose,
+  file,
+  onSave,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isDrawing, setIsDrawing] = useState(false);
+  const [imageLoaded, setImageLoaded] = useState(false);
+  
+  // Store the original image so we can clear/redraw it
+  const imageObjRef = useRef<HTMLImageElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen || !file) {
+      setImageLoaded(false);
+      return;
+    }
+
+    const img = new Image();
+    const objectUrl = URL.createObjectURL(file);
+    img.src = objectUrl;
+    img.onload = () => {
+      imageObjRef.current = img;
+      drawImageToCanvas();
+      setImageLoaded(true);
+      URL.revokeObjectURL(objectUrl);
+    };
+  }, [isOpen, file]);
+
+  const drawImageToCanvas = () => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    const img = imageObjRef.current;
+    
+    if (!canvas || !container || !img) return;
+    
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    // Calculate dimensions to fit within modal (max 600px wide/high)
+    const maxWidth = container.clientWidth;
+    const maxHeight = window.innerHeight * 0.6;
+    
+    let targetWidth = img.width;
+    let targetHeight = img.height;
+    
+    const ratio = Math.min(maxWidth / img.width, maxHeight / img.height);
+    
+    if (ratio < 1) {
+      targetWidth = img.width * ratio;
+      targetHeight = img.height * ratio;
+    }
+
+    canvas.width = targetWidth;
+    canvas.height = targetHeight;
+    
+    // Fill white background first (in case of transparency)
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    
+    ctx.drawImage(img, 0, 0, targetWidth, targetHeight);
+    
+    // Set up pen style
+    ctx.strokeStyle = '#ef4444'; // red-500
+    ctx.lineWidth = 4;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+  };
+
+  const getCoordinates = (e: React.MouseEvent | React.TouchEvent | MouseEvent | TouchEvent) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
+    
+    const rect = canvas.getBoundingClientRect();
+    let clientX, clientY;
+    
+    if ('touches' in e) {
+      clientX = e.touches[0].clientX;
+      clientY = e.touches[0].clientY;
+    } else {
+      clientX = (e as React.MouseEvent).clientX;
+      clientY = (e as React.MouseEvent).clientY;
+    }
+    
+    return {
+      x: clientX - rect.left,
+      y: clientY - rect.top
+    };
+  };
+
+  const startDrawing = (e: React.MouseEvent | React.TouchEvent) => {
+    e.preventDefault();
+    setIsDrawing(true);
+    const { x, y } = getCoordinates(e);
+    const ctx = canvasRef.current?.getContext('2d');
+    if (ctx) {
+      ctx.beginPath();
+      ctx.moveTo(x, y);
+    }
+  };
+
+  const draw = (e: React.MouseEvent | React.TouchEvent) => {
+    e.preventDefault();
+    if (!isDrawing) return;
+    const { x, y } = getCoordinates(e);
+    const ctx = canvasRef.current?.getContext('2d');
+    if (ctx) {
+      ctx.lineTo(x, y);
+      ctx.stroke();
+    }
+  };
+
+  const stopDrawing = () => {
+    if (isDrawing) {
+      const ctx = canvasRef.current?.getContext('2d');
+      if (ctx) {
+        ctx.closePath();
+      }
+      setIsDrawing(false);
+    }
+  };
+
+  const handleClear = () => {
+    drawImageToCanvas();
+  };
+
+  const handleSave = () => {
+    const canvas = canvasRef.current;
+    if (!canvas || !file) return;
+
+    canvas.toBlob((blob) => {
+      if (!blob) return;
+      
+      const parts = file.name.split('.');
+      const ext = parts.pop();
+      const baseName = parts.join('.');
+      const newName = `${baseName}_annotated.${ext || 'jpg'}`;
+      
+      const newFile = new File([blob], newName, { type: blob.type });
+      onSave(newFile);
+      onClose();
+    }, file.type);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Annotate Photo"
+      size="lg"
+    >
+      <div className="flex flex-col items-center space-y-4">
+        {!imageLoaded && (
+          <div className="h-64 flex items-center justify-center text-gray-500">
+            Loading image...
+          </div>
+        )}
+        
+        <div 
+          ref={containerRef}
+          className={`w-full overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-800 flex justify-center ${!imageLoaded ? 'hidden' : ''}`}
+        >
+          <canvas
+            ref={canvasRef}
+            onMouseDown={startDrawing}
+            onMouseMove={draw}
+            onMouseUp={stopDrawing}
+            onMouseOut={stopDrawing}
+            onTouchStart={startDrawing}
+            onTouchMove={draw}
+            onTouchEnd={stopDrawing}
+            onTouchCancel={stopDrawing}
+            className="cursor-crosshair max-w-full touch-none border border-gray-200 dark:border-gray-700 shadow-sm"
+          />
+        </div>
+        
+        <div className="flex justify-between w-full mt-4">
+          <Button type="button" variant="secondary" onClick={handleClear} className="flex items-center">
+            <Undo className="w-4 h-4 mr-2" />
+            Clear
+          </Button>
+          
+          <div className="flex space-x-2">
+            <Button type="button" variant="secondary" onClick={onClose} className="flex items-center">
+              <X className="w-4 h-4 mr-2" />
+              Cancel
+            </Button>
+            <Button type="button" variant="primary" onClick={handleSave} className="flex items-center">
+              <Check className="w-4 h-4 mr-2" />
+              Save Annotation
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ImageAnnotationModal;

--- a/client/src/components/ImageUploadZone.tsx
+++ b/client/src/components/ImageUploadZone.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback } from 'react';
-import { UploadCloud, X, File as FileIcon } from 'lucide-react';
+import React, { useCallback, useState } from 'react';
+import { UploadCloud, X, File as FileIcon, PenTool } from 'lucide-react';
+import ImageAnnotationModal from './ImageAnnotationModal';
 
 interface ImageUploadZoneProps {
   files: File[];
@@ -14,6 +15,8 @@ const ImageUploadZone: React.FC<ImageUploadZoneProps> = ({
   maxFiles = 5, 
   maxSizeMB = 5 
 }) => {
+  const [annotatingFileIndex, setAnnotatingFileIndex] = useState<number | null>(null);
+
   const handleDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
@@ -53,6 +56,13 @@ const ImageUploadZone: React.FC<ImageUploadZoneProps> = ({
     onChange(files.filter((_, index) => index !== indexToRemove));
   };
 
+  const handleSaveAnnotation = (annotatedFile: File) => {
+    if (annotatingFileIndex === null) return;
+    const newFiles = [...files];
+    newFiles[annotatingFileIndex] = annotatedFile;
+    onChange(newFiles);
+  };
+
   return (
     <div className="w-full">
       <div 
@@ -90,16 +100,38 @@ const ImageUploadZone: React.FC<ImageUploadZoneProps> = ({
                 )}
                 <span className="text-xs truncate text-gray-700 dark:text-gray-200 max-w-[150px]">{file.name}</span>
               </div>
-              <button 
-                type="button" 
-                onClick={(e) => { e.stopPropagation(); removeFile(index); }}
-                className="p-1 flex-shrink-0 text-gray-400 hover:text-red-500 transition-colors"
-              >
-                <X className="w-4 h-4" />
-              </button>
+              <div className="flex items-center space-x-1 flex-shrink-0">
+                {file.type.includes('image') && (
+                  <button 
+                    type="button" 
+                    onClick={(e) => { e.stopPropagation(); setAnnotatingFileIndex(index); }}
+                    className="p-1 text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
+                    title="Annotate Image"
+                  >
+                    <PenTool className="w-4 h-4" />
+                  </button>
+                )}
+                <button 
+                  type="button" 
+                  onClick={(e) => { e.stopPropagation(); removeFile(index); }}
+                  className="p-1 text-gray-400 hover:text-red-500 transition-colors"
+                  title="Remove File"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
             </div>
           ))}
         </div>
+      )}
+
+      {annotatingFileIndex !== null && (
+        <ImageAnnotationModal
+          isOpen={true}
+          onClose={() => setAnnotatingFileIndex(null)}
+          file={files[annotatingFileIndex]}
+          onSave={handleSaveAnnotation}
+        />
       )}
     </div>
   );

--- a/client/src/components/NFCScanner.tsx
+++ b/client/src/components/NFCScanner.tsx
@@ -1,0 +1,106 @@
+import React, { useState, useEffect } from 'react';
+import { Wifi, X } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
+
+const NFCScanner: React.FC = () => {
+  const [isSupported, setIsSupported] = useState(false);
+  const [isScanning, setIsScanning] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if ('NDEFReader' in window) {
+      setIsSupported(true);
+    }
+  }, []);
+
+  const handleScan = async () => {
+    if (!isSupported) {
+      toast.error('NFC scanning is not supported on this device or browser.');
+      return;
+    }
+
+    try {
+      setIsScanning(true);
+      // @ts-ignore - Web NFC API is not in standard TypeScript lib yet
+      const ndef = new NDEFReader();
+      await ndef.scan();
+
+      toast.loading('Ready to scan. Tap NFC tag...', { id: 'nfc-scan' });
+
+      // @ts-ignore
+      ndef.addEventListener("readingerror", () => {
+        toast.error("Cannot read data from the NFC tag. Try another one.", { id: 'nfc-scan' });
+        setIsScanning(false);
+      });
+
+      // @ts-ignore
+      ndef.addEventListener("reading", ({ message, serialNumber }) => {
+        const record = message.records[0];
+        if (!record) {
+          toast.error("NFC tag is empty.", { id: 'nfc-scan' });
+          setIsScanning(false);
+          return;
+        }
+
+        // @ts-ignore
+        const textDecoder = new TextDecoder(record.encoding || 'utf-8');
+        const equipmentId = textDecoder.decode(record.data).trim();
+
+        if (equipmentId) {
+          toast.success(`Scanned: ${equipmentId}`, { id: 'nfc-scan' });
+          setIsScanning(false);
+          navigate(`/equipment/${equipmentId}`);
+        } else {
+          toast.error("Invalid equipment ID on tag.", { id: 'nfc-scan' });
+          setIsScanning(false);
+        }
+      });
+    } catch (error: any) {
+      console.error(error);
+      setIsScanning(false);
+      toast.error(`NFC Error: ${error.message}`, { id: 'nfc-scan' });
+    }
+  };
+
+  const cancelScan = () => {
+    setIsScanning(false);
+    toast.dismiss('nfc-scan');
+    // Note: The Web NFC API currently does not have a reliable abort() mechanism across all implementations.
+    // The easiest way is to let the user know it's cancelled and ignore further events via state, 
+    // or just let it timeout. For simplicity, we just reset the UI state.
+  };
+
+  if (!isSupported) {
+    return null; // Don't show the button if the device doesn't support Web NFC
+  }
+
+  return (
+    <div className="relative">
+      {isScanning ? (
+        <button
+          onClick={cancelScan}
+          className="flex items-center justify-center p-3 h-12 w-12 rounded-2xl bg-red-100 text-red-600 hover:bg-red-200 transition-all border border-red-200 shadow-sm animate-pulse"
+          title="Cancel NFC Scan"
+        >
+          <X className="w-5 h-5" />
+        </button>
+      ) : (
+        <button
+          onClick={handleScan}
+          className="flex items-center justify-center p-3 h-12 w-12 rounded-2xl bg-blue-100 text-blue-600 hover:bg-blue-200 transition-all border border-blue-200 shadow-sm group relative"
+          title="Scan NFC Tag"
+        >
+          <Wifi className="w-5 h-5 rotate-90 group-hover:scale-110 transition-transform" />
+          
+          {/* Tooltip */}
+          <div className="absolute top-full mt-2 w-max left-1/2 -translate-x-1/2 px-2 py-1 bg-gray-800 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10">
+            Tap NFC Tag
+          </div>
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default NFCScanner;

--- a/client/src/components/RequestModal.tsx
+++ b/client/src/components/RequestModal.tsx
@@ -14,9 +14,11 @@ import TicketComments from './TicketComments';
 import RequestToolsTab from './RequestToolsTab';
 import { MaintenanceRequest } from '../types';
 import { ShieldCheck, CheckCircle, AlertCircle } from 'lucide-react';
-import ImageUploadZone from './ImageUploadZone';
-import ImageGallery from './ImageGallery';
+import ImageUploadZone from "./ImageUploadZone";
+import ImageGallery from "./ImageGallery";
+import AudioDiagnosticLogger from "./AudioDiagnosticLogger";
 import axios from 'axios';
+import ToolSelectModal from "./ToolSelectModal";
 import RCAWizardModal from './RCAWizardModal';
 import CannibalizeModal from './CannibalizeModal';
 import Select from "react-select";
@@ -1181,12 +1183,17 @@ const RequestModal: React.FC<RequestModalProps> = ({
             <h4 className="text-xs font-semibold text-gray-500 mb-2 uppercase tracking-wider">
               Upload New Attachments
             </h4>
-            <ImageUploadZone 
-              files={attachments} 
-              onChange={setAttachments} 
-              maxFiles={5} 
-              maxSizeMB={5} 
-            />
+            <div className="space-y-4">
+              <ImageUploadZone 
+                files={attachments} 
+                onChange={setAttachments} 
+                maxFiles={5} 
+                maxSizeMB={5} 
+              />
+              <AudioDiagnosticLogger 
+                onAudioRecorded={(file) => setAttachments(prev => [...prev, file])} 
+              />
+            </div>
           </div>
         </div>
 

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -15,6 +15,7 @@ import { globalSearch } from '../services/searchService';
 import SearchDropdown from '../components/SearchDropdown';
 import { getHighRiskEquipment } from '../services/predictiveService';
 import RequestModal from '../components/RequestModal';
+import NFCScanner from '../components/NFCScanner';
 
 const Dashboard: React.FC = () => {
   const { t } = useTranslation();
@@ -244,10 +245,11 @@ const Dashboard: React.FC = () => {
         </div>
       )}
 
-      {/* Search */}
+      {/* Search & NFC Scan */}
       <div className="rounded-3xl border border-white/50 dark:border-gray-700 bg-white/70 dark:bg-gray-800/70 p-4 shadow-lg backdrop-blur-sm md:p-5">
-        <div ref={searchRef} className="relative w-full">
-          <Search className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500 md:h-5 md:w-5" />
+        <div className="flex gap-3 items-center w-full">
+          <div ref={searchRef} className="relative flex-1">
+            <Search className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500 md:h-5 md:w-5" />
 
           <input
             type="text"
@@ -292,6 +294,8 @@ const Dashboard: React.FC = () => {
               }}
             />
           )}
+        </div>
+        <NFCScanner />
         </div>
       </div>
 


### PR DESCRIPTION
## 📌 Pull Request Title

"Tap-to-Open" NFC Machine Scanning (#356)

---

## 🚀 Description

Added a native Web NFC scanner directly to the main Dashboard to replace manual typing! Mechanics can now effortlessly tap their smartphone against an equipment NFC sticker to jump straight into its profile and active tickets.

---

## 🔗 Related Issue

Closes #356 

---

## 📝 Changes Made

- Web NFC Integration: Created a brand new NFCScanner.tsx component leveraging the native NDEFReader API available in modern mobile browsers.
- Device Compatibility: The system detects whether the browser/device supports Web NFC. If it is unsupported (like on iOS Safari or Desktop), the button gracefully hides itself so as not to clutter the UI.
- Dashboard Layout Update: Modified the main Dashboard.tsx Search component layout to house the new "Wifi/Scan" icon button beautifully beside the text input.
- Instant Redirects: Once a tag is tapped, the scanner decodes the NDEF payload, extracts the Equipment ID string, and utilizes React Router to instantly redirect the mechanic to /equipment/:id. No more fat-finger typing errors on the factory floor!

---

## 🧪 Testing Performed

- [x] Tested locally
- [x] Templates render correctly on GitHub

---

## 🏷️ NSoC'26 Information

- **Level:** Level 3
- **Points:** 10

---

## ✅ Checklist

- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] This PR does not break existing functionality
- [x] I have added necessary documentation

---

## ⚠️ Important

- PR without issue assignment will be **rejected**
- Missing `NSoC'26` tag will be **requested for update**

---

Thank you for your contribution! 🎉