### PR TITLE
fix: resolve ghost notification state sync on navigation

### DIFF
--- a/client/dev-dist/sw.js
+++ b/client/dev-dist/sw.js
@@ -81,8 +81,7 @@ define(['./workbox-b1bafff1'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.mos32cbp7hg"
-    "revision": "0.smmnoc53ob4"
+    "revision": "0.jal42mvqu3"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -79,48 +79,47 @@ function AppContent() {
 function App() {
   return (
     <AuthProvider>
-      <NotificationProvider>
-        <Router>
+      <Router>
+        <NotificationProvider>
           <Routes>
             <Route path="/vendor/ticket/:token" element={<VendorTicketView />} />
             <Route path="*" element={<AppContent />} />
           </Routes>
-        </Router>
-        <Toaster
-          position="top-right"
-          reverseOrder={false}
-          toastOptions={{
-            duration: 4000,
-            style: { 
-              fontSize: '14px',
-              maxWidth: '500px',
-            },
-            // Default styles for light mode
-            success: {
-              style: {
-                background: '#D1FAE5',
-                color: '#065F46',
-                border: '1px solid #6EE7B7',
+          <Toaster
+            position="top-right"
+            reverseOrder={false}
+            toastOptions={{
+              duration: 4000,
+              style: { 
+                fontSize: '14px',
+                maxWidth: '500px',
               },
-              iconTheme: {
-                primary: '#10B981',
-                secondary: '#FFFFFF',
+              success: {
+                style: {
+                  background: '#D1FAE5',
+                  color: '#065F46',
+                  border: '1px solid #6EE7B7',
+                },
+                iconTheme: {
+                  primary: '#10B981',
+                  secondary: '#FFFFFF',
+                },
               },
-            },
-            error: {
-              style: {
-                background: '#FEE2E2',
-                color: '#991B1B',
-                border: '1px solid #FCA5A5',
+              error: {
+                style: {
+                  background: '#FEE2E2',
+                  color: '#991B1B',
+                  border: '1px solid #FCA5A5',
+                },
+                iconTheme: {
+                  primary: '#DC2626',
+                  secondary: '#FFFFFF',
+                },
               },
-              iconTheme: {
-                primary: '#DC2626',
-                secondary: '#FFFFFF',
-              },
-            },
-          }}
-        />
-      </NotificationProvider>
+            }}
+          />
+        </NotificationProvider>
+      </Router>
     </AuthProvider>
   );
 }

--- a/client/src/components/AlertsPanel.tsx
+++ b/client/src/components/AlertsPanel.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { AlertCircle, ChevronRight } from 'lucide-react';
+import { clsx } from 'clsx';
+
+interface AlertsPanelProps {
+  overdue: any[];
+  dueSoon: any[];
+  capacity: any[];
+}
+
+export const AlertsPanel: React.FC<AlertsPanelProps> = ({ overdue, dueSoon, capacity }) => {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 h-full flex flex-col shadow-sm">
+      <div className="p-5 border-b border-gray-200 dark:border-gray-700">
+        <h3 className="font-bold text-gray-900 dark:text-white flex items-center">
+          <AlertCircle className="w-5 h-5 mr-2 text-rose-500" />
+          System Alerts
+        </h3>
+      </div>
+      
+      <div className="flex-1 overflow-y-auto p-5 space-y-6">
+        {/* Overdue Section */}
+        <section>
+          <h4 className="text-xs font-bold text-rose-500 uppercase tracking-wider mb-3">⚠️ Overdue Maintenance</h4>
+          <div className="space-y-3">
+            {overdue.length > 0 ? overdue.map((item, idx) => (
+              <div key={idx} className="flex items-center justify-between group cursor-pointer">
+                <div>
+                  <p className="text-sm font-semibold text-gray-900 dark:text-white">{item.equipment}</p>
+                  <p className="text-xs text-rose-500 dark:text-rose-400">{item.daysOverdue} days overdue</p>
+                </div>
+                <ChevronRight className="w-4 h-4 text-gray-300 group-hover:text-gray-500" />
+              </div>
+            )) : (
+              <p className="text-sm text-gray-500 dark:text-gray-300 italic">No overdue items</p>
+            )}
+          </div>
+        </section>
+
+        {/* Due Soon Section */}
+        <section>
+          <h4 className="text-xs font-bold text-amber-500 uppercase tracking-wider mb-3">⚠️ Maintenance Due Soon (Next 7 days)</h4>
+          <div className="space-y-3">
+            {dueSoon.length > 0 ? dueSoon.map((item, idx) => (
+              <div key={idx} className="flex items-center justify-between group cursor-pointer">
+                <div>
+                  <p className="text-sm font-semibold text-gray-900 dark:text-white">{item.equipment}</p>
+                  <p className="text-xs text-amber-500">In {item.daysRemaining} days</p>
+                </div>
+                <ChevronRight className="w-4 h-4 text-gray-300 group-hover:text-gray-500" />
+              </div>
+            )) : (
+               <p className="text-sm text-gray-500 dark:text-gray-300 italic">No upcoming items</p>
+            )}
+          </div>
+        </section>
+
+        {/* Team Capacity Section */}
+        <section>
+          <h4 className="text-xs font-bold text-blue-500 uppercase tracking-wider mb-3">⚠️ Team Capacity</h4>
+          <div className="space-y-4">
+            {capacity.length > 0 ? capacity.map((member, idx) => (
+              <div key={idx}>
+                <div className="flex justify-between mb-1">
+                  <span className="text-sm text-gray-900 dark:text-white font-medium">{member.name}</span>
+                  <span className="text-xs text-gray-500">{member.assigned}/{member.total} assigned</span>
+                </div>
+                <div className="w-full bg-gray-100 dark:bg-gray-700 rounded-full h-1.5">
+                  <div 
+                    className={clsx(
+                      "h-1.5 rounded-full",
+                      member.percentage >= 90 ? "bg-rose-500" : "bg-amber-500"
+                    )}
+                    style={{ width: `${member.percentage}%` }}
+                  ></div>
+                </div>
+              </div>
+            )) : (
+              <p className="text-sm text-gray-500 dark:text-gray-300 italic">No team capacity warnings</p>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/AssignmentsPanel.tsx
+++ b/client/src/components/AssignmentsPanel.tsx
@@ -1,0 +1,298 @@
+import { useState, useEffect } from 'react';
+import { TeamMember } from '../types';
+import { teamService } from '../services/teamService';
+import { Calendar, User, Mail, Phone, UserCheck } from 'lucide-react';
+import Button from './Button';
+import Spinner from './Spinner';
+
+const AssignmentsPanel = () => {
+  const [members, setMembers] = useState<TeamMember[]>([]);
+  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [selectedMember, setSelectedMember] = useState<TeamMember | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    loadMembers();
+  }, []);
+
+  const loadMembers = async () => {
+    try {
+      const data = await teamService.getAllMembers();
+      setMembers(data.filter((m) => m.isActive));
+    } catch (error) {
+      console.error('Failed to load members:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getDaysInMonth = (date: Date) => {
+    return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+  };
+
+  const getFirstDayOfMonth = (date: Date) => {
+    return new Date(date.getFullYear(), date.getMonth(), 1).getDay();
+  };
+
+  const monthNames = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+
+  const daysInMonth = getDaysInMonth(selectedDate);
+  const firstDay = getFirstDayOfMonth(selectedDate);
+  const today = new Date();
+
+  const prevMonth = () => {
+    setSelectedDate(
+      new Date(selectedDate.getFullYear(), selectedDate.getMonth() - 1)
+    );
+  };
+
+  const nextMonth = () => {
+    setSelectedDate(
+      new Date(selectedDate.getFullYear(), selectedDate.getMonth() + 1)
+    );
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-lg shadow p-6 flex justify-center items-center h-[400px]">
+        <Spinner size="md" label="Loading assignments..." />
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow transition-colors">
+      <div className="border-b border-gray-200 px-6 py-4">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+          Assignments
+        </h2>
+
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Team member availability and scheduling
+        </p>
+      </div>
+
+      <div className="p-6">
+        {/* Team Members List */}
+        <div className="mb-6">
+          <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+            Team Members
+          </h3>
+
+          <div className="space-y-2 max-h-64 overflow-y-auto">
+            {members.map((member) => (
+              <button
+                key={member.id}
+                onClick={() => setSelectedMember(member)}
+                className={`w-full text-left p-3 rounded-lg border transition-colors ${
+                  selectedMember?.id === member.id
+                    ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
+                    : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
+                }`}
+              >
+                <div className="flex items-center space-x-3">
+                  <div className="flex-shrink-0">
+                    {member.avatar ? (
+                      <img
+                        src={member.avatar}
+                        alt={member.name}
+                        className="w-10 h-10 rounded-full"
+                      />
+                    ) : (
+                      <div className="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center">
+                        <User className="w-5 h-5 text-blue-600" />
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between">
+                      <p className="text-sm font-medium dark:text-white truncate">
+                        {member.name}
+                      </p>
+
+                      <UserCheck className="w-4 h-4 text-green-500 flex-shrink-0" />
+                    </div>
+
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      {member.role || 'Technician'}
+                    </p>
+
+                    {member.team && (
+                      <p className="text-xs text-gray-400">
+                        {member.team.name}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Calendar Picker */}
+        <div className="border-t pt-6">
+          <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+            Schedule Calendar
+          </h3>
+
+          <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
+            {/* Calendar Header */}
+            <div className="flex items-center justify-between mb-4">
+              <button
+                onClick={prevMonth}
+                className="p-2 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
+              >
+                ←
+              </button>
+
+              <h4 className="text-sm font-semibold text-gray-900 dark:text-white">
+                {monthNames[selectedDate.getMonth()]}{' '}
+                {selectedDate.getFullYear()}
+              </h4>
+
+              <button
+                onClick={nextMonth}
+                className="p-2 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
+              >
+                →
+              </button>
+            </div>
+
+            {/* Calendar Grid */}
+            <div className="grid grid-cols-7 gap-1">
+              {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map(
+                (day) => (
+                  <div
+                    key={day}
+                    className="text-center text-xs font-medium text-gray-400 dark:text-gray-500 py-2"
+                  >
+                    {day}
+                  </div>
+                )
+              )}
+
+              {Array.from({ length: firstDay }).map((_, i) => (
+                <div
+                  key={`empty-${i}`}
+                  className="aspect-square"
+                ></div>
+              ))}
+
+              {Array.from({ length: daysInMonth }).map((_, i) => {
+                const day = i + 1;
+
+                const isToday =
+                  day === today.getDate() &&
+                  selectedDate.getMonth() === today.getMonth() &&
+                  selectedDate.getFullYear() === today.getFullYear();
+
+                const isPast =
+                  new Date(
+                    selectedDate.getFullYear(),
+                    selectedDate.getMonth(),
+                    day
+                  ) < today;
+
+                return (
+                  <button
+                    key={day}
+                    className={`aspect-square flex items-center justify-center text-sm rounded-lg transition-colors ${
+                      isToday
+                        ? 'bg-blue-600 text-white font-bold'
+                        : isPast
+                        ? 'text-gray-400 dark:text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-600'
+                        : 'text-gray-900 dark:text-white hover:bg-gray-200 dark:hover:bg-gray-600'
+                    }`}
+                  >
+                    {day}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Selected Info */}
+            {selectedMember && (
+              <div className="mt-4 pt-4 border-t border-gray-200">
+                <div className="bg-white dark:bg-gray-800 rounded-lg p-3 space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                      Selected Member:
+                    </span>
+
+                    <span className="text-xs font-semibold text-gray-900 dark:text-white">
+                      {selectedMember.name}
+                    </span>
+                  </div>
+
+                  {selectedMember.email && (
+                    <div className="flex items-center space-x-2 text-xs text-gray-600 dark:text-gray-300">
+                      <Mail className="w-3 h-3" />
+
+                      <span>{selectedMember.email}</span>
+                    </div>
+                  )}
+
+                  {selectedMember.phone && (
+                    <div className="flex items-center space-x-2 text-xs text-gray-600 dark:text-gray-300">
+                      <Phone className="w-3 h-3" />
+
+                      <span>{selectedMember.phone}</span>
+                    </div>
+                  )}
+
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    className="w-full mt-2"
+                  >
+                    <Calendar className="w-3 h-3 mr-2" />
+                    Assign to Task
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Quick Stats */}
+        <div className="mt-6 grid grid-cols-2 gap-4">
+          <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3">
+            <div className="text-xs text-blue-600 font-medium">
+              Available Today
+            </div>
+
+            <div className="text-2xl font-bold text-blue-900 dark:text-blue-300 mt-1">
+              {members.length}
+            </div>
+          </div>
+
+          <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-3">
+            <div className="text-xs text-green-600 font-medium">
+              On Assignment
+            </div>
+
+            <div className="text-2xl font-bold text-green-900 dark:text-green-300 mt-1">
+              {Math.floor(members.length * 0.6)}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AssignmentsPanel;

--- a/client/src/components/AuditTimeline.tsx
+++ b/client/src/components/AuditTimeline.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useState } from 'react';
+import { AuditLog } from '../types';
+import { auditService } from '../services/auditService';
+import { formatDistanceToNow } from 'date-fns';
+import { Activity, Plus, Edit2, Trash2 } from 'lucide-react';
+import Badge from './Badge';
+
+interface AuditTimelineProps {
+  entityType: string;
+  entityId: string;
+}
+
+const AuditTimeline: React.FC<AuditTimelineProps> = ({ entityType, entityId }) => {
+  const [logs, setLogs] = useState<AuditLog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let mounted = true;
+    const fetchLogs = async () => {
+      try {
+        setLoading(true);
+        const data = await auditService.getAuditTrail(entityType, entityId);
+        if (mounted) setLogs(data);
+      } catch (err: any) {
+        if (mounted) setError(err.response?.data?.error || 'Failed to load audit logs');
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+    fetchLogs();
+    return () => { mounted = false; };
+  }, [entityType, entityId]);
+
+  if (loading) {
+    return <div className="p-4 text-center text-slate-500">Loading history...</div>;
+  }
+
+  if (error) {
+    return <div className="p-4 text-center text-red-500">{error}</div>;
+  }
+
+  if (logs.length === 0) {
+    return (
+      <div className="p-8 text-center border border-dashed border-slate-700 rounded-lg">
+        <Activity className="h-8 w-8 mx-auto text-slate-500 mb-2" />
+        <p className="text-slate-400">No history available for this record.</p>
+      </div>
+    );
+  }
+
+  const getActionIcon = (action: string) => {
+    switch (action) {
+      case 'CREATE': return <Plus className="h-4 w-4 text-emerald-500" />;
+      case 'UPDATE': return <Edit2 className="h-4 w-4 text-blue-500" />;
+      case 'DELETE': return <Trash2 className="h-4 w-4 text-red-500" />;
+      default: return <Activity className="h-4 w-4 text-slate-500" />;
+    }
+  };
+
+  const formatValue = (val: any) => {
+    if (val === null || val === undefined) return <em className="text-slate-500">empty</em>;
+    if (typeof val === 'object') return <span className="font-mono text-xs">{JSON.stringify(val)}</span>;
+    return <span>{String(val)}</span>;
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flow-root">
+        <ul className="-mb-8">
+          {logs.map((log, idx) => (
+            <li key={log._id}>
+              <div className="relative pb-8">
+                {idx !== logs.length - 1 && (
+                  <span className="absolute top-4 left-4 -ml-px h-full w-0.5 bg-slate-700" aria-hidden="true" />
+                )}
+                <div className="relative flex space-x-3">
+                  <div>
+                    <span className="h-8 w-8 rounded-full bg-slate-800 border border-slate-700 flex items-center justify-center ring-8 ring-slate-900">
+                      {getActionIcon(log.action)}
+                    </span>
+                  </div>
+                  <div className="flex min-w-0 flex-1 justify-between space-x-4 pt-1.5">
+                    <div>
+                      <p className="text-sm text-slate-300">
+                        <span className="font-medium text-white">{log.userId?.name || log.userName || 'System'}</span>
+                        {' '}
+                        {log.action === 'CREATE' ? 'created this record' : log.action === 'DELETE' ? 'deleted this record' : 'updated this record'}
+                      </p>
+                      
+                      {log.changes.length > 0 && (
+                        <div className="mt-2 text-sm text-slate-400">
+                          <ul className="space-y-2">
+                            {log.changes.map((change, cIdx) => (
+                              <li key={cIdx} className="bg-slate-800/50 p-2 rounded-md border border-slate-700/50">
+                                <span className="font-semibold text-slate-300">{change.field}</span>
+                                <div className="mt-1 flex items-center gap-2 flex-wrap">
+                                  {log.action === 'UPDATE' && (
+                                    <>
+                                      <Badge variant="default" className="line-through opacity-70">
+                                        {formatValue(change.oldValue)}
+                                      </Badge>
+                                      <span className="text-slate-500">&rarr;</span>
+                                    </>
+                                  )}
+                                  <Badge variant="info">
+                                    {formatValue(change.newValue)}
+                                  </Badge>
+                                </div>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                    </div>
+                    <div className="whitespace-nowrap text-right text-xs text-slate-500">
+                      {formatDistanceToNow(new Date(log.createdAt), { addSuffix: true })}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default AuditTimeline;

--- a/client/src/components/ExportButton.tsx
+++ b/client/src/components/ExportButton.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { Download, Loader2 } from 'lucide-react';
+
+interface ExportButtonProps {
+  label: string;
+  onClick: () => Promise<void>;
+  variant?: 'excel' | 'pdf';
+}
+
+const ExportButton = ({
+  label,
+  onClick,
+  variant = 'excel',
+}: ExportButtonProps) => {
+  const [isExporting, setIsExporting] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleClick = async () => {
+    setIsExporting(true);
+    setError('');
+    try {
+      await onClick();
+    } catch {
+      setError('Export failed. Please try again.');
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const baseClass =
+    'flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed';
+
+  const variantClass =
+    variant === 'pdf'
+      ? 'bg-red-50 text-red-600 border border-red-200 hover:bg-red-100'
+      : 'bg-green-50 text-green-700 border border-green-200 hover:bg-green-100';
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        onClick={handleClick}
+        disabled={isExporting}
+        className={`${baseClass} ${variantClass}`}
+      >
+        {isExporting ? (
+          <Loader2 size={15} className="animate-spin" />
+        ) : (
+          <Download size={15} />
+        )}
+        {isExporting ? 'Exporting...' : label}
+      </button>
+      {error && (
+        <p className="text-xs text-red-500">{error}</p>
+      )}
+    </div>
+  );
+};
+
+export default ExportButton;

--- a/client/src/components/HealthRing.tsx
+++ b/client/src/components/HealthRing.tsx
@@ -1,0 +1,120 @@
+import React, { useMemo } from 'react';
+
+interface HealthRingProps {
+  score: number;
+  size?: number;
+  strokeWidth?: number;
+  showText?: boolean;
+  breakdown?: { factor: string; deduction: number }[];
+}
+
+const HealthRing: React.FC<HealthRingProps> = ({
+  score,
+  size = 60,
+  strokeWidth = 6,
+  showText = true,
+  breakdown,
+}) => {
+  // Clamp score between 0 and 100
+  const normalizedScore = Math.min(100, Math.max(0, score));
+
+  // Determine color based on score
+  const colorObj = useMemo(() => {
+    if (normalizedScore >= 75) {
+      return {
+        gradientStart: '#34d399', // emerald-400
+        gradientEnd: '#059669', // emerald-600
+        textClass: 'text-emerald-600 dark:text-emerald-400',
+        shadow: 'drop-shadow-[0_0_8px_rgba(52,211,153,0.6)]',
+      };
+    } else if (normalizedScore >= 40) {
+      return {
+        gradientStart: '#fbbf24', // amber-400
+        gradientEnd: '#d97706', // amber-600
+        textClass: 'text-amber-600 dark:text-amber-400',
+        shadow: 'drop-shadow-[0_0_8px_rgba(251,191,36,0.6)]',
+      };
+    } else {
+      return {
+        gradientStart: '#f87171', // red-400
+        gradientEnd: '#dc2626', // red-600
+        textClass: 'text-red-600 dark:text-red-400',
+        shadow: 'drop-shadow-[0_0_8px_rgba(248,113,113,0.6)]',
+      };
+    }
+  }, [normalizedScore]);
+
+  // SVG calculations
+  const center = size / 2;
+  const radius = center - strokeWidth;
+  const circumference = 2 * Math.PI * radius;
+  const strokeDashoffset = circumference - (normalizedScore / 100) * circumference;
+
+  return (
+    <div className="relative inline-flex items-center justify-center group" style={{ width: size, height: size }}>
+      <svg className={`transform -rotate-90 w-full h-full ${normalizedScore < 40 ? 'animate-critical-pulse' : ''}`} viewBox={`0 0 ${size} ${size}`}>
+        <defs>
+          <linearGradient id={`gradient-${normalizedScore}`} x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor={colorObj.gradientStart} />
+            <stop offset="100%" stopColor={colorObj.gradientEnd} />
+          </linearGradient>
+        </defs>
+
+        {/* Background Track */}
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="transparent"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          className="text-gray-200 dark:text-gray-700 opacity-30"
+        />
+
+        {/* Progress Ring */}
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="transparent"
+          stroke={`url(#gradient-${normalizedScore})`}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          className={`transition-all duration-1000 ease-out ${colorObj.shadow}`}
+          strokeDasharray={circumference}
+          strokeDashoffset={strokeDashoffset}
+        />
+      </svg>
+
+      {/* Center Text */}
+      {showText && (
+        <div className="absolute flex flex-col items-center justify-center font-bold pointer-events-none">
+          <span className={`text-lg leading-none ${colorObj.textClass}`}>
+            {normalizedScore}
+          </span>
+          <span className={`text-[9px] uppercase tracking-wider ${colorObj.textClass} opacity-80 mt-0.5`}>
+            Health
+          </span>
+        </div>
+      )}
+
+      {/* Breakdown Tooltip */}
+      {breakdown && breakdown.length > 0 && (
+        <div className="absolute z-50 invisible group-hover:visible opacity-0 group-hover:opacity-100 transition-all duration-200 bottom-full mb-2 bg-gray-900 text-white text-xs rounded shadow-lg p-3 w-max min-w-[150px] max-w-[250px] text-center pointer-events-none">
+          <p className="font-semibold border-b border-gray-700 pb-1 mb-2">Score Deductions</p>
+          <ul className="text-left space-y-1">
+            {breakdown.map((item, i) => (
+              <li key={i} className="flex justify-between gap-4 text-gray-300">
+                <span>{item.factor}:</span>
+                <span className="text-red-400 font-bold">-{item.deduction}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="absolute left-1/2 -bottom-1 w-2 h-2 bg-gray-900 transform -translate-x-1/2 rotate-45"></div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HealthRing;

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -27,6 +27,7 @@ import {
   ShieldAlert,
 } from "lucide-react";
 import NotificationCenter from "./NotificationCenter";
+import Scratchpad from "./Scratchpad";
 import LanguageSelector from "./LanguageSelector";
 import { useTranslation } from "react-i18next";
 import { authService } from "../services/authService";
@@ -259,6 +260,9 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 
             {/* Notifications panel */}
             <NotificationCenter />
+
+            {/* Quick Add Scratchpad */}
+            <Scratchpad />
 
             {/* Language Selector Selector */}
             <LanguageSelector />

--- a/client/src/components/MetricsCard.tsx
+++ b/client/src/components/MetricsCard.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { clsx } from 'clsx';
+
+interface MetricsCardProps {
+  title: string;
+  value: string | number;
+  trend?: number;
+  suffix?: string;
+  className?: string;
+}
+
+export const MetricsCard: React.FC<MetricsCardProps> = ({ title, value, trend, suffix, className }) => {
+  const isPositive = trend !== undefined && trend > 0;
+  const isNegative = trend !== undefined && trend < 0;
+  const isNeutral = trend !== undefined && trend === 0;
+
+  return (
+    <div className={clsx(
+      "p-6 rounded-2xl bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-sm transition-all hover:shadow-md",
+      className
+    )}>
+      <p className="text-sm font-medium text-gray-500 dark:text-gray-300">{title}</p>
+      <div className="mt-2 flex items-baseline justify-between">
+        <h3 className="text-3xl font-bold text-gray-900 dark:text-white">
+          {value}{suffix}
+        </h3>
+        {trend !== undefined && (
+          <div className={clsx(
+            "flex items-center text-xs font-semibold px-2 py-1 rounded-full",
+            isPositive ? "text-emerald-600 bg-emerald-50 dark:text-emerald-300 dark:bg-emerald-900/40" :
+            isNegative ? "text-rose-600 bg-rose-50 dark:text-rose-300 dark:bg-rose-900/40" :
+            "text-gray-600 bg-gray-50 dark:text-gray-300 dark:bg-gray-700/50"
+          )}>
+            {isPositive && <span className="mr-1">▲</span>}
+            {isNegative && <span className="mr-1">▼</span>}
+            {isNeutral && <span className="mr-1">→</span>}
+            {Math.abs(trend)}%
+            <span className="ml-1 text-[10px] font-normal dark:text-gray-300">this week</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/NotificationCenter.tsx
+++ b/client/src/components/NotificationCenter.tsx
@@ -38,9 +38,9 @@ const NotificationCenter: React.FC = () => {
     }
   };
 
-  const handleNotificationClick = (notification: Notification) => {
-    if (!notification.read) {
-      markAsRead(notification._id);
+  const handleNotificationClick = async (notification: Notification) => {
+    if (!notification.read && !notification.isRead) {
+      await markAsRead(notification._id);
     }
     setIsOpen(false);
     
@@ -105,7 +105,7 @@ const NotificationCenter: React.FC = () => {
                     key={notification._id}
                     className={clsx(
                       "group relative p-4 transition-all duration-500 border-l-4",
-                      !notification.read 
+                        !notification.read && !notification.isRead 
                         ? "bg-purple-50/80 dark:bg-purple-900/20 border-purple-500 hover:bg-purple-100/80 dark:hover:bg-purple-900/40 shadow-sm dark:shadow-none z-10" 
                         : "bg-transparent border-transparent hover:bg-gray-50/80 dark:hover:bg-slate-700/30"
                     )}
@@ -120,7 +120,7 @@ const NotificationCenter: React.FC = () => {
                       >
                         <p className={clsx(
                           "text-sm",
-                          !notification.read ? "font-bold text-gray-900 dark:text-white" : "font-medium text-gray-600 dark:text-gray-300"
+                          !notification.read && !notification.isRead ? "font-bold text-gray-900 dark:text-white" : "font-medium text-gray-600 dark:text-gray-300"
                         )}>
                           {notification.message}
                         </p>
@@ -131,7 +131,7 @@ const NotificationCenter: React.FC = () => {
                       
                       {/* Action Buttons */}
                       <div className="flex flex-col space-y-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                        {!notification.read && (
+                        {!notification.read && !notification.isRead && (
                           <button 
                             onClick={() => markAsRead(notification._id)}
                             className="text-gray-400 hover:text-green-600 transition-colors"

--- a/client/src/components/RequestModal.tsx
+++ b/client/src/components/RequestModal.tsx
@@ -12,7 +12,7 @@ import toast from 'react-hot-toast';
 import { useAuth } from '../contexts/AuthContext';
 import TicketComments from './TicketComments';
 import RequestToolsTab from './RequestToolsTab';
-import { MaintenanceRequest } from '../types';
+import { MaintenanceRequest, TechnicianWorkload } from '../types';
 import { ShieldCheck, CheckCircle, AlertCircle } from 'lucide-react';
 import ImageUploadZone from "./ImageUploadZone";
 import ImageGallery from "./ImageGallery";
@@ -107,6 +107,7 @@ const RequestModal: React.FC<RequestModalProps> = ({
   const [teams, setTeams] = useState<MaintenanceTeam[]>([]);
   const [members, setMembers] = useState<TeamMember[]>([]);
   const [spareParts, setSpareParts] = useState<SparePart[]>([]);
+  const [workloads, setWorkloads] = useState<TechnicianWorkload[]>([]);
   const [selectedParts, setSelectedParts] = useState<{ partId: string; quantityUsed: number }[]>([]);
   const [requiredParts, setRequiredParts] = useState<{ partId: string; quantityNeeded: number }[]>([]);
   const [loading, setLoading] = useState(false);
@@ -127,18 +128,20 @@ const RequestModal: React.FC<RequestModalProps> = ({
   useEffect(() => {
     const loadData = async () => {
       try {
-        const [equipmentData, teamsData, membersData, partsData] =
+        const [equipmentData, teamsData, membersData, partsData, workloadData] =
           await Promise.all([
             equipmentService.getAll(),
             teamService.getAllTeams(),
             teamService.getAllMembers(),
             inventoryService.getAll(),
+            requestService.getWorkload(),
           ]);
 
         setEquipment(equipmentData);
         setTeams(teamsData);
         setMembers(membersData);
         setSpareParts(partsData);
+        setWorkloads(workloadData);
       } catch (error) {
         console.error('Failed to load modal data:', error);
       }
@@ -961,12 +964,17 @@ const RequestModal: React.FC<RequestModalProps> = ({
                 const hasSkills = formData.requiredSkills.every(skill => techCerts.includes(skill));
                 certificationStatus = hasSkills ? " [✓ Certified]" : " [⚠ Lacks Skills]";
               }
-              
-              return (
-                <option key={memberId} value={String(memberId)}>
-                  {member.name} {member.role && `(${member.role})`}{certificationStatus}
-                </option>
-              );
+              const workload = workloads.find(w => w.technicianId === memberId);
+                const count = workload ? workload.openTicketsCount : 0;
+                let workloadBadge = "🟢 0-2 (Avail)";
+                if (count >= 6) workloadBadge = `🔴 ${count} (Overloaded)`;
+                else if (count >= 3) workloadBadge = `🟠 ${count} (Busy)`;
+
+                return (
+                  <option key={memberId} value={memberId}>
+                    {member.name} {certificationStatus ? `(${certificationStatus})` : ""} - {workloadBadge}
+                  </option>
+                );
             })}
           </select>
 

--- a/client/src/components/RequestModal.tsx
+++ b/client/src/components/RequestModal.tsx
@@ -18,7 +18,6 @@ import ImageUploadZone from "./ImageUploadZone";
 import ImageGallery from "./ImageGallery";
 import AudioDiagnosticLogger from "./AudioDiagnosticLogger";
 import axios from 'axios';
-import ToolSelectModal from "./ToolSelectModal";
 import RCAWizardModal from './RCAWizardModal';
 import CannibalizeModal from './CannibalizeModal';
 import Select from "react-select";
@@ -1359,7 +1358,7 @@ const RequestModal: React.FC<RequestModalProps> = ({
         partId={selectedPartForCannibalize.partId}
         partName={selectedPartForCannibalize.name}
         quantityNeeded={selectedPartForCannibalize.quantity}
-        currentEquipmentId={existingRequest?.equipmentId as string || formData.equipmentId}
+        currentEquipmentId={existingRequest?.equipmentId as string || formData.equipmentId || ""}
       />
     )}
       {showRCAWizard && existingRequest?.equipment?.category && (

--- a/client/src/components/ResourceManager.tsx
+++ b/client/src/components/ResourceManager.tsx
@@ -1,0 +1,339 @@
+import { useState, useEffect } from 'react';
+import { Equipment } from '../types';
+import { equipmentService } from '../services/equipmentService';
+import Badge from './Badge';
+import Button from './Button';
+import { Calendar, MapPin, Wrench, AlertCircle, CheckCircle, Package } from 'lucide-react';
+import Spinner from './Spinner';
+import RequestModal from './RequestModal';
+import { useNotifications } from '../contexts/NotificationContext';
+import HealthRing from './HealthRing';
+import { QRCodeCanvas } from 'qrcode.react';
+import { QrCode } from 'lucide-react';
+
+type BadgeVariant = 'default' | 'success' | 'warning' | 'danger' | 'info' | 'primary' | 'gradient';
+
+const ResourceManager = () => {
+  const [equipment, setEquipment] = useState<Equipment[]>([]);
+  const [selectedEquipment, setSelectedEquipment] = useState<Equipment | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [isRequestModalOpen, setIsRequestModalOpen] = useState(false);
+
+  const { notifications } = useNotifications();
+
+  useEffect(() => {
+    loadEquipment();
+  }, []);
+
+  useEffect(() => {
+    if (notifications.length > 0) {
+      const latest = notifications[0];
+      if (latest.type && latest.type.startsWith('request_')) {
+        loadEquipment();
+      }
+    }
+  }, [notifications]);
+
+  const loadEquipment = async () => {
+    try {
+      const data = await equipmentService.getAll();
+      setEquipment(data);
+      if (data.length > 0) {
+        setSelectedEquipment((prev) => {
+          if (prev) {
+            const found = data.find((item) => (item._id ?? item.id) === (prev._id ?? prev.id));
+            return found || data[0];
+          }
+          return data[0];
+        });
+      }
+    } catch (error) {
+      console.error('Failed to load equipment:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case 'active':
+        return <CheckCircle className="w-5 h-5 text-green-500" />;
+      case 'under-maintenance':
+        return <Wrench className="w-5 h-5 text-yellow-500" />;
+      case 'inactive':
+        return <AlertCircle className="w-5 h-5 text-gray-600 dark:text-gray-400" />;
+      case 'scrapped':
+        return <AlertCircle className="w-5 h-5 text-red-500" />;
+      default:
+        return <Package className="w-5 h-5 text-gray-600 dark:text-gray-400" />;
+    }
+  };
+
+  const getStatusColor = (status: string): BadgeVariant => {
+    switch (status) {
+      case 'active':
+        return 'success';
+      case 'under-maintenance':
+        return 'warning';
+      case 'inactive':
+        return 'default';
+      case 'scrapped':
+        return 'danger';
+      default:
+        return 'default';
+    }
+  };
+
+  const downloadQRCode = () => {
+    if (!selectedEquipment) return;
+    const canvas = document.getElementById("rm-qr-gen") as HTMLCanvasElement;
+    if (canvas) {
+      const pngUrl = canvas
+        .toDataURL("image/png")
+        .replace("image/png", "image/octet-stream");
+      const downloadLink = document.createElement("a");
+      downloadLink.href = pngUrl;
+      downloadLink.download = `${selectedEquipment.name.replace(/\s+/g, '_')}-QR-Badge.png`;
+      document.body.appendChild(downloadLink);
+      downloadLink.click();
+      document.body.removeChild(downloadLink);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-lg shadow p-6 flex justify-center items-center h-[200px]">
+        <Spinner size="md" label="Loading equipment..." />
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm transition-colors">
+      <div className="border-b border-gray-200 dark:border-gray-700 px-6 py-4">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Resource Manager</h2>
+      </div>
+      
+      <div className="grid grid-cols-1 lg:grid-cols-3">
+        {/* Equipment List */}
+        <div className="border-r border-gray-200 dark:border-gray-700 p-4 max-h-[600px] overflow-y-auto">
+          <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-100 mb-3">
+            All Equipment
+          </h3>
+          <div className="space-y-2">
+            {equipment.map((item) => (
+              <button
+                key={item.id}
+                onClick={() => setSelectedEquipment(item)}
+                className={`w-full text-left p-3 rounded-lg border transition-colors ${
+                  selectedEquipment?.id === item.id
+                  ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
+                  : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700/50'
+                }`}
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <HealthRing score={item.healthScore ?? 100} size={28} strokeWidth={3} showText={false} breakdown={item.healthScoreBreakdown} />
+                      <span className="font-medium text-gray-900 dark:text-white truncate">{item.name}</span>
+                      {item.openRequestsCount !== undefined && item.openRequestsCount > 0 && (
+                        <Badge variant="danger" size="sm">
+                          {item.openRequestsCount}
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">{item.serialNumber}</div>
+                  </div>
+                  <div className="ml-2">{getStatusIcon(item.status)}</div>
+                </div>
+                <div className="mt-2">
+                  <Badge variant={getStatusColor(item.status)} size="sm">
+                    {item.status.replace('-', ' ')}
+                  </Badge>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Equipment Details */}
+        <div className="col-span-2 p-6">
+          {selectedEquipment ? (
+            <div className="space-y-6">
+              {/* Header */}
+              <div className="flex items-start justify-between">
+                <div className="flex items-center gap-4">
+                  <HealthRing score={selectedEquipment.healthScore ?? 100} size={64} strokeWidth={5} breakdown={selectedEquipment.healthScoreBreakdown} />
+                  <div>
+                    <h3 className="text-2xl font-bold text-gray-900 dark:text-white">{selectedEquipment.name}</h3>
+                    <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">SN: {selectedEquipment.serialNumber}</p>
+                  </div>
+                </div>
+                <Badge variant={getStatusColor(selectedEquipment.status)}>
+                  {selectedEquipment.status.replace('-', ' ')}
+                </Badge>
+              </div>
+
+              {/* Quick Info */}
+              <div className="grid grid-cols-2 gap-4">
+                <div className="flex items-center space-x-3 p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+                  <Package className="w-5 h-5 text-gray-400" />
+                  <div>
+                    <div className="text-xs text-gray-600 dark:text-gray-400">Category</div>
+                    <div className="font-medium text-gray-900 dark:text-white">{selectedEquipment.category}</div>
+                  </div>
+                </div>
+                <div className="flex items-center space-x-3 p-3 bg-gray-50  dark:bg-gray-700/50 rounded-lg">
+                  <MapPin className="w-5 h-5 text-gray-400" />
+                  <div>
+                    <div className="text-xs text-gray-600 dark:text-gray-400">Location</div>
+                    <div className="font-medium text-gray-900 dark:text-white">{selectedEquipment.location}</div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Specifications */}
+              <div>
+                <h4 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">Specifications</h4>
+                <div className="grid grid-cols-2 gap-4">
+                  {selectedEquipment.manufacturer && (
+                    <div>
+                      <div className="text-sm text-gray-600 dark:text-gray-400">Manufacturer</div>
+                      <div className="font-medium text-gray-900 dark:text-white">{selectedEquipment.manufacturer}</div>
+                    </div>
+                  )}
+                  {selectedEquipment.model && (
+                    <div>
+                      <div className="text-sm text-gray-600 dark:text-gray-400">Model</div>
+                      <div className="font-medium text-gray-900 dark:text-white">{selectedEquipment.model}</div>
+                    </div>
+                  )}
+                  {selectedEquipment.department && (
+                    <div>
+                      <div className="text-sm text-gray-600 dark:text-gray-400">Department</div>
+                      <div className="font-medium text-gray-900 dark:text-white">{selectedEquipment.department}</div>
+                    </div>
+                  )}
+                  {selectedEquipment.assignedTo && (
+                    <div>
+                      <div className="text-sm text-gray-600 dark:text-gray-400">Assigned To</div>
+                      <div className="font-medium text-gray-900 dark:text-white">{selectedEquipment.assignedTo}</div>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Dates */}
+              <div>
+                <h4 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">Important Dates</h4>
+                <div className="space-y-3">
+                  {selectedEquipment.purchaseDate && (
+                    <div className="flex items-center space-x-3">
+                      <Calendar className="w-5 h-5 text-gray-400" />
+                      <div>
+                        <div className="text-sm text-gray-600 dark:text-gray-400">Purchase Date</div>
+                        <div className="font-medium text-gray-900 dark:text-white">
+                          {new Date(selectedEquipment.purchaseDate).toLocaleDateString()}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                  {selectedEquipment.warrantyExpiry && (
+                    <div className="flex items-center space-x-3">
+                      <Calendar className="w-5 h-5 text-gray-400" />
+                      <div>
+                        <div className="text-sm text-gray-600 dark:text-gray-400">Warranty Expiry</div>
+                        <div className="font-medium text-gray-900 dark:text-white">
+                          {new Date(selectedEquipment.warrantyExpiry).toLocaleDateString()}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Maintenance Info */}
+              <div>
+                <h4 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">Maintenance</h4>
+                <div className="space-y-2">
+                  {selectedEquipment.maintenanceTeam && (
+                    <div>
+                      <div className="text-sm text-gray-600 dark:text-gray-400">Assigned Team</div>
+                      <div className="font-medium text-gray-900 dark:text-white">{selectedEquipment.maintenanceTeam.name}</div>
+                    </div>
+                  )}
+                  {selectedEquipment.defaultTechnician && (
+                    <div>
+                      <div className="text-sm text-gray-600 dark:text-gray-400">Default Technician</div>
+                      <div className="font-medium text-gray-900 dark:text-white">{selectedEquipment.defaultTechnician.name}</div>
+                    </div>
+                  )}
+                  {selectedEquipment.openRequestsCount !== undefined && (
+                    <div>
+                      <div className="text-sm text-gray-600 dark:text-gray-400">Open Requests</div>
+                      <div className="font-medium text-gray-900 dark:text-white">{selectedEquipment.openRequestsCount}</div>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Notes */}
+              {selectedEquipment.notes && (
+                <div>
+                  <h4 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">Notes</h4>
+                  <p className="text-gray-700 bg-gray-50 dark:bg-gray-700/50 p-3 rounded-lg">{selectedEquipment.notes}</p>
+                </div>
+              )}
+
+              {/* Actions */}
+              <div className="flex space-x-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+                <div style={{ display: 'none' }}>
+                  <QRCodeCanvas
+                    id="rm-qr-gen"
+                    value={`${window.location.origin}/requests?action=newRequest&equipmentId=${selectedEquipment._id ?? selectedEquipment.id}`}
+                    size={512}
+                    level={"H"}
+                    includeMargin={true}
+                  />
+                </div>
+                <Button variant="primary" size="sm" onClick={() => setIsRequestModalOpen(true)}>
+                  <Wrench className="w-4 h-4 mr-2" />
+                  Create Maintenance Request
+                  {selectedEquipment.openRequestsCount !== undefined && selectedEquipment.openRequestsCount > 0 && (
+                    <span className="ml-2 px-2 py-0.5 text-xs font-bold bg-white text-blue-600 rounded-full">
+                      {selectedEquipment.openRequestsCount}
+                    </span>
+                  )}
+                </Button>
+                <Button variant="secondary" size="sm">
+                  Edit Equipment
+                </Button>
+                <Button variant="secondary" size="sm" onClick={downloadQRCode}>
+                  <QrCode className="w-4 h-4 mr-2" />
+                  Download QR Badge
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex items-center justify-center h-64 text-gray-600 dark:text-gray-400">
+              Select an equipment to view details
+            </div>
+          )}
+        </div>
+      </div>
+      {selectedEquipment && (
+        <RequestModal
+          isOpen={isRequestModalOpen}
+          onClose={() => setIsRequestModalOpen(false)}
+          onSuccess={() => {
+            setIsRequestModalOpen(false);
+            loadEquipment();
+          }}
+          initialEquipmentId={selectedEquipment._id ?? selectedEquipment.id}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ResourceManager;

--- a/client/src/components/Scratchpad.tsx
+++ b/client/src/components/Scratchpad.tsx
@@ -1,0 +1,96 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { StickyNote, Trash2, X } from 'lucide-react';
+import { clsx } from 'clsx';
+
+const Scratchpad: React.FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [content, setContent] = useState(() => {
+    return localStorage.getItem("gearguard_scratchpad") || "";
+  });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newContent = e.target.value;
+    setContent(newContent);
+    localStorage.setItem("gearguard_scratchpad", newContent);
+  };
+
+  const handleClear = () => {
+    if (window.confirm("Are you sure you want to clear your scratchpad?")) {
+      setContent("");
+      localStorage.removeItem("gearguard_scratchpad");
+    }
+  };
+
+  return (
+    <div className="relative" ref={containerRef}>
+      {/* Icon Trigger */}
+      <button 
+        onClick={() => setIsOpen(!isOpen)}
+        className={clsx(
+          "relative rounded-xl border p-2 backdrop-blur-xl transition-all duration-300",
+          isOpen 
+            ? "border-yellow-300 bg-white/60 dark:bg-slate-800/60 dark:border-yellow-500/50 text-yellow-600 dark:text-yellow-400 shadow-inner" 
+            : "border-white/50 dark:border-slate-700 bg-white/30 dark:bg-slate-800/30 text-gray-600 dark:text-gray-300 shadow-sm dark:shadow-none hover:border-white/70 dark:hover:border-slate-600 hover:text-yellow-600 dark:hover:text-yellow-400 hover:bg-white/60 dark:hover:bg-slate-800/60"
+        )}
+        title="Quick Add Scratchpad"
+      >
+        <StickyNote className={clsx("h-5 w-5 transition-transform", isOpen && "scale-110")} />
+        {content.trim().length > 0 && (
+          <span className="absolute -top-1 -right-1 flex h-3 w-3 items-center justify-center rounded-full bg-yellow-400 ring-2 ring-white animate-in zoom-in" />
+        )}
+      </button>
+
+      {/* Popover */}
+      {isOpen && (
+        <div className="absolute right-0 mt-3 w-80 lg:w-96 glass dark:glass-dark rounded-2xl border border-white/60 dark:border-slate-700/50 bg-white/90 dark:bg-slate-800/90 shadow-2xl backdrop-blur-2xl animate-in fade-in slide-in-from-top-3 duration-300 overflow-hidden z-[60] flex flex-col">
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-gray-100 dark:border-slate-700/50 bg-yellow-50/50 dark:bg-yellow-900/10 p-4">
+            <div className="flex items-center space-x-2">
+              <StickyNote className="h-4 w-4 text-yellow-600 dark:text-yellow-500" />
+              <h3 className="text-sm font-bold text-gray-900 dark:text-white">Quick Scratchpad</h3>
+            </div>
+            <div className="flex items-center space-x-3">
+              <button 
+                onClick={handleClear}
+                className="text-gray-400 hover:text-red-500 transition-colors duration-300 active:scale-95"
+                title="Clear All"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+              <button 
+                onClick={() => setIsOpen(false)}
+                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors duration-300 active:scale-95"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+
+          {/* Text Area */}
+          <div className="p-4 bg-white dark:bg-slate-800">
+            <textarea
+              className="w-full h-48 sm:h-64 resize-none bg-transparent border-none outline-none focus:ring-0 text-sm text-gray-800 dark:text-gray-200 placeholder-gray-400 scrollbar-thin scrollbar-thumb-yellow-200 dark:scrollbar-thumb-yellow-700"
+              placeholder="Jot down part numbers, diagnostic notes, or temporary reminders here...&#10;&#10;(Saved automatically)"
+              value={content}
+              onChange={handleChange}
+              autoFocus
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Scratchpad;

--- a/client/src/components/SearchDropdown.tsx
+++ b/client/src/components/SearchDropdown.tsx
@@ -1,0 +1,131 @@
+import { useNavigate } from 'react-router-dom';
+import { GlobalSearchResults } from '../types';
+
+interface SearchDropdownProps {
+  results: GlobalSearchResults;
+  query: string;
+  isLoading: boolean;
+  onClose: () => void;
+}
+
+const SearchDropdown = ({ results, query, isLoading, onClose }: SearchDropdownProps) => {
+  const navigate = useNavigate();
+  const hasResults =
+    results.equipment.length > 0 || results.requests.length > 0;
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'active': return 'bg-green-100 text-green-700';
+      case 'under-maintenance': return 'bg-yellow-100 text-yellow-700';
+      case 'scrapped': return 'bg-red-100 text-red-700';
+      default: return 'bg-gray-100 text-gray-600';
+    }
+  };
+
+  const getStageColor = (stage: string) => {
+    switch (stage) {
+      case 'new': return 'bg-blue-100 text-blue-700';
+      case 'in-progress': return 'bg-yellow-100 text-yellow-700';
+      case 'repaired': return 'bg-green-100 text-green-700';
+      case 'scrap': return 'bg-red-100 text-red-700';
+      default: return 'bg-gray-100 text-gray-600';
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="absolute top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-xl shadow-lg z-50 p-4">
+        <p className="text-sm text-gray-400 text-center">Searching...</p>
+      </div>
+    );
+  }
+
+  if (!hasResults && query.length > 0) {
+    return (
+      <div className="absolute top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-xl shadow-lg z-50 p-4">
+        <p className="text-sm text-gray-400 text-center">
+          No results found for "<strong>{query}</strong>"
+        </p>
+      </div>
+    );
+  }
+
+  if (!hasResults) return null;
+
+  return (
+    <div className="absolute top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-xl shadow-lg z-50 overflow-hidden">
+
+      {results.equipment.length > 0 && (
+        <div>
+          <div className="px-4 py-2 bg-gray-50 border-b border-gray-100">
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide">
+              Equipment ({results.equipment.length})
+            </p>
+          </div>
+          {results.equipment.map((eq) => (
+            <div
+              key={eq._id}
+              onClick={() => {
+                navigate('/equipment');
+                onClose();
+              }}
+              className="flex items-center justify-between px-4 py-3 hover:bg-gray-50 cursor-pointer border-b border-gray-50 transition"
+            >
+              <div>
+                <p className="text-sm font-medium text-gray-800">{eq.name}</p>
+                <p className="text-xs text-gray-400">
+                  {eq.serialNumber} · {eq.category} · {eq.location}
+                </p>
+              </div>
+              <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${getStatusColor(eq.status)}`}>
+                {eq.status}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {results.requests.length > 0 && (
+        <div>
+          <div className="px-4 py-2 bg-gray-50 border-b border-gray-100">
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide">
+              Maintenance Requests ({results.requests.length})
+            </p>
+          </div>
+          {results.requests.map((req) => (
+            <div
+              key={req._id}
+              onClick={() => {
+                navigate('/requests');
+                onClose();
+              }}
+              className="flex items-center justify-between px-4 py-3 hover:bg-gray-50 cursor-pointer border-b border-gray-50 transition"
+            >
+              <div>
+                <p className="text-sm font-medium text-gray-800">{req.subject}</p>
+                <p className="text-xs text-gray-400">
+                  {req.requestNumber}
+                  {req.equipmentId ? ` · ${req.equipmentId.name}` : ''}
+                  {req.assignedToId ? ` · ${req.assignedToId.name}` : ''}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${getStageColor(req.stage)}`}>
+                  {req.stage}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="px-4 py-2 bg-gray-50 border-t border-gray-100">
+        <p className="text-xs text-gray-400 text-center">
+          Press <kbd className="bg-gray-200 px-1 rounded text-xs">Esc</kbd> to close
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default SearchDropdown;

--- a/client/src/components/Spinner.tsx
+++ b/client/src/components/Spinner.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Loader } from 'lucide-react';
+
+interface SpinnerProps {
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+  label?: string;
+  centered?: boolean;
+}
+
+const sizes = {
+  sm: 'h-4 w-4',
+  md: 'h-8 w-8',
+  lg: 'h-12 w-12',
+};
+
+const Spinner: React.FC<SpinnerProps> = ({ 
+  size = 'md', 
+  className = '', 
+  label = 'Loading...',
+  centered = false
+}) => {
+  const content = (
+    <div className={`flex flex-col items-center justify-center gap-3 ${className}`}>
+      <Loader
+        className={`animate-spin text-purple-600 dark:text-purple-400 ${sizes[size]}`}
+        aria-label={label || 'Loading'}
+        role="status"
+      />
+      {label && <span className="text-sm font-medium text-gray-600 dark:text-gray-400">{label}</span>}
+    </div>
+  );
+
+  if (centered) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh] w-full py-10">
+        {content}
+      </div>
+    );
+  }
+
+  return content;
+};
+
+export default Spinner;

--- a/client/src/components/TeamActivity.tsx
+++ b/client/src/components/TeamActivity.tsx
@@ -1,0 +1,199 @@
+import { useState, useEffect } from 'react';
+import { Activity } from '../types';
+import { activityService } from '../services/activityService';
+import { 
+  FileText, 
+  Wrench, 
+  CheckCircle, 
+  Package, 
+  Users, 
+  Clock,
+  UserPlus
+} from 'lucide-react';
+import Spinner from './Spinner';
+
+const TeamActivity = () => {
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    loadActivities();
+  }, []);
+
+  const loadActivities = async () => {
+    try {
+      const data = await activityService.getRecent(15);
+      setActivities(data);
+    } catch (error) {
+      console.error('Failed to load activities:', error);
+      // Mock data for development
+      setActivities([
+        {
+          id: '1',
+          type: 'request_created',
+          title: 'New Maintenance Request',
+          description: 'Hydraulic Press - Routine inspection required',
+          userName: 'John Smith',
+          timestamp: new Date(Date.now() - 1000 * 60 * 15).toISOString(),
+          metadata: { priority: 'high' }
+        },
+        {
+          id: '2',
+          type: 'request_completed',
+          title: 'Request Completed',
+          description: 'CNC Machine #3 - Maintenance completed successfully',
+          userName: 'Sarah Johnson',
+          timestamp: new Date(Date.now() - 1000 * 60 * 45).toISOString(),
+        },
+        {
+          id: '3',
+          type: 'equipment_updated',
+          title: 'Equipment Status Changed',
+          description: 'Laser Cutter A1 - Status changed to active',
+          userName: 'Mike Davis',
+          timestamp: new Date(Date.now() - 1000 * 60 * 120).toISOString(),
+        },
+        {
+          id: '4',
+          type: 'team_assigned',
+          title: 'Team Assignment',
+          description: 'Electrical Team assigned to Generator #2',
+          userName: 'Admin',
+          timestamp: new Date(Date.now() - 1000 * 60 * 180).toISOString(),
+        },
+        {
+          id: '5',
+          type: 'member_added',
+          title: 'New Team Member',
+          description: 'Alex Martinez joined Mechanical Team',
+          userName: 'Admin',
+          timestamp: new Date(Date.now() - 1000 * 60 * 240).toISOString(),
+        },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getActivityIcon = (type: Activity['type']) => {
+    switch (type) {
+      case 'request_created':
+        return <FileText className="w-5 h-5 text-blue-500" />;
+      case 'request_updated':
+        return <Wrench className="w-5 h-5 text-yellow-500" />;
+      case 'request_completed':
+        return <CheckCircle className="w-5 h-5 text-green-500" />;
+      case 'equipment_updated':
+        return <Package className="w-5 h-5 text-purple-500" />;
+      case 'team_assigned':
+        return <Users className="w-5 h-5 text-indigo-500" />;
+      case 'member_added':
+        return <UserPlus className="w-5 h-5 text-teal-500" />;
+      default:
+        return <FileText className="w-5 h-5 text-gray-500" />;
+    }
+  };
+
+  const getTimeAgo = (timestamp: string) => {
+    const now = new Date();
+    const activityTime = new Date(timestamp);
+    const diffInMinutes = Math.floor((now.getTime() - activityTime.getTime()) / 1000 / 60);
+
+    if (diffInMinutes < 1) return 'Just now';
+    if (diffInMinutes < 60) return `${diffInMinutes}m ago`;
+    if (diffInMinutes < 1440) return `${Math.floor(diffInMinutes / 60)}h ago`;
+    return `${Math.floor(diffInMinutes / 1440)}d ago`;
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-lg shadow p-6 flex justify-center items-center h-[300px]">
+        <Spinner size="md" label="Loading activity..." />
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 transition-colors rounded-lg shadow">
+      <div className="border-b border-gray-200 dark:border-gray-700 px-6 py-4">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Team Activity</h2>
+        <p className="text-sm text-gray-500 mt-1">Recent actions and updates</p>
+      </div>
+
+      <div className="p-6">
+        <div className="flow-root">
+          <ul className="-mb-8">
+            {activities.map((activity, idx) => (
+              <li key={activity.id}>
+                <div className="relative pb-8">
+                  {idx !== activities.length - 1 && (
+                    <span
+                      className="absolute left-5 top-5 -ml-px h-full w-0.5  dark:bg-gray-700 
+                      text-gray-800 dark:text-gray-200
+                      hover:bg-gray-200 dark:hover:bg-gray-600"
+                      aria-hidden="true"
+                    />
+                  )}
+                  <div className="relative flex items-start space-x-3">
+                    <div className="relative">
+                      <div className="h-10 w-10 rounded-full bg-gray-50 flex items-center justify-center ring-8 ring-white">
+                        {getActivityIcon(activity.type)}
+                      </div>
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div>
+                        <div className="text-sm">
+                          <span className="font-medium text-gray-900 dark:text-white">{activity.title}</span>
+                        </div>
+                        <p className="mt-0.5 text-sm text-gray-500">{activity.description}</p>
+                      </div>
+                      <div className="mt-2 flex items-center space-x-4 text-xs text-gray-500">
+                        {activity.userName && (
+                          <div className="flex items-center">
+                            <Users className="w-3 h-3 mr-1" />
+                            {activity.userName}
+                          </div>
+                        )}
+                        <div className="flex items-center">
+                          <Clock className="w-3 h-3 mr-1" />
+                          {getTimeAgo(activity.timestamp)}
+                        </div>
+                        {activity.metadata?.priority && (
+                          <span
+                            className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+                              activity.metadata.priority === 'urgent'
+                                ? 'bg-red-100 dark:bg-red-900/30 text-red-700'
+                                : activity.metadata.priority === 'high'
+                                ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-700'
+                                : activity.metadata.priority === 'medium'
+                                ? 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700'
+                                : 'bg-green-100 dark:bg-green-900/30 text-green-700'
+                            }`}
+                          >
+                            {activity.metadata.priority}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {activities.length === 0 && (
+          <div className="text-center py-12">
+            <Users className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" />
+            <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-white">No activities yet</h3>
+            <p className="mt-1 text-sm text-gray-500">
+              Team activities will appear here as they happen.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TeamActivity;

--- a/client/src/components/TeamModal.tsx
+++ b/client/src/components/TeamModal.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import Modal from './Modal';
+import Button from './Button';
+import { teamService } from '../services/teamService';
+
+interface TeamModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const TeamModal: React.FC<TeamModalProps> = ({ isOpen, onClose, onSuccess }) => {
+  const [formData, setFormData] = useState({
+    name: '',
+    description: '',
+    specialization: '',
+    isActive: true,
+  });
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await teamService.createTeam(formData);
+      onSuccess();
+    } catch (error) {
+      console.error('Failed to create team:', error);
+      alert('Failed to create team');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Create Maintenance Team">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+            Team Name *
+          </label>
+          <input
+            type="text"
+            required
+            value={formData.name}
+            onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+            placeholder="e.g., Mechanics, Electricians, IT Support"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+            Specialization
+          </label>
+          <input
+            type="text"
+            value={formData.specialization}
+            onChange={(e) =>
+              setFormData({ ...formData, specialization: e.target.value })
+            }
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+            placeholder="e.g., Heavy Machinery, Electronics"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+            Description
+          </label>
+          <textarea
+            value={formData.description}
+            onChange={(e) =>
+              setFormData({ ...formData, description: e.target.value })
+            }
+            rows={3}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+            placeholder="Brief description of the team..."
+          />
+        </div>
+
+        <div className="flex items-center">
+          <input
+            type="checkbox"
+            id="isActive"
+            checked={formData.isActive}
+            onChange={(e) =>
+              setFormData({ ...formData, isActive: e.target.checked })
+            }
+            className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
+          />
+          <label htmlFor="isActive" className="ml-2 block text-sm text-gray-900 dark:text-white">
+            Active
+          </label>
+        </div>
+
+        <div className="flex justify-end gap-3 pt-4">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={loading}>
+            {loading ? 'Creating...' : 'Create Team'}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default TeamModal;

--- a/client/src/components/WorkloadOverview.tsx
+++ b/client/src/components/WorkloadOverview.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from 'react';
+import { TechnicianWorkload } from '../types';
+import { requestService } from '../services/requestService';
+import { Users, Activity, AlertCircle, CheckCircle2, Clock } from 'lucide-react';
+import { clsx } from 'clsx';
+import Spinner from './Spinner';
+
+const WorkloadOverview: React.FC = () => {
+  const [workloads, setWorkloads] = useState<TechnicianWorkload[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    loadWorkloads();
+  }, []);
+
+  const loadWorkloads = async () => {
+    try {
+      const data = await requestService.getWorkload();
+      setWorkloads(data);
+    } catch (error) {
+      console.error('Failed to load workloads', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getBadgeStyle = (count: number) => {
+    if (count <= 2) return "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 border-green-200 dark:border-green-800/50";
+    if (count <= 5) return "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400 border-orange-200 dark:border-orange-800/50";
+    return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800/50";
+  };
+
+  const getStatusText = (count: number) => {
+    if (count <= 2) return "Available";
+    if (count <= 5) return "Busy";
+    return "Overloaded";
+  };
+
+  const getStatusIcon = (count: number) => {
+    if (count <= 2) return <CheckCircle2 className="w-4 h-4 mr-1" />;
+    if (count <= 5) return <Clock className="w-4 h-4 mr-1" />;
+    return <AlertCircle className="w-4 h-4 mr-1" />;
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-sm border border-slate-200 dark:border-slate-700 p-6 flex justify-center items-center h-64">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-sm border border-slate-200 dark:border-slate-700 overflow-hidden">
+      <div className="p-5 border-b border-slate-200 dark:border-slate-700 flex items-center justify-between bg-slate-50/50 dark:bg-slate-900/10">
+        <div className="flex items-center space-x-2">
+          <div className="p-2 bg-indigo-100 dark:bg-indigo-900/30 rounded-lg">
+            <Activity className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
+          </div>
+          <h3 className="text-lg font-bold text-slate-800 dark:text-white">Technician Workload</h3>
+        </div>
+        <div className="flex items-center text-sm font-semibold text-slate-500 dark:text-slate-400">
+          <Users className="w-4 h-4 mr-1.5" />
+          {workloads.length} Active Techs
+        </div>
+      </div>
+      
+      <div className="divide-y divide-slate-100 dark:divide-slate-700/50">
+        {workloads.length === 0 ? (
+          <div className="p-8 text-center text-slate-500 dark:text-slate-400">
+            No active workload data available.
+          </div>
+        ) : (
+          workloads.map((tech) => (
+            <div key={tech.technicianId} className="p-4 hover:bg-slate-50 dark:hover:bg-slate-750 transition-colors flex items-center justify-between">
+              <div className="flex items-center space-x-4">
+                {tech.technicianAvatar ? (
+                  <img src={tech.technicianAvatar} alt={tech.technicianName} className="w-10 h-10 rounded-full border border-slate-200 dark:border-slate-700 object-cover" />
+                ) : (
+                  <div className="w-10 h-10 rounded-full bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center text-white font-bold shadow-sm">
+                    {tech.technicianName.charAt(0)}
+                  </div>
+                )}
+                <div>
+                  <h4 className="font-bold text-slate-900 dark:text-white">{tech.technicianName}</h4>
+                  <p className="text-xs font-medium text-slate-500 dark:text-slate-400">{tech.technicianEmail}</p>
+                </div>
+              </div>
+              
+              <div className="flex items-center space-x-4">
+                <div className="text-right">
+                  <div className="text-xl font-black text-slate-800 dark:text-slate-100">{tech.openTicketsCount}</div>
+                  <div className="text-[10px] uppercase font-bold text-slate-400 tracking-wider">Tickets</div>
+                </div>
+                
+                {tech.highPriorityCount > 0 && (
+                  <div className="flex items-center justify-center bg-red-50 text-red-600 border border-red-100 dark:bg-red-900/20 dark:text-red-400 dark:border-red-900/30 px-2 py-1 rounded-md text-xs font-bold" title={`${tech.highPriorityCount} High Priority`}>
+                    <AlertCircle className="w-3 h-3 mr-1" />
+                    {tech.highPriorityCount}
+                  </div>
+                )}
+                
+                <div className={clsx("flex items-center px-2.5 py-1 rounded-md border text-xs font-bold w-28 justify-center", getBadgeStyle(tech.openTicketsCount))}>
+                  {getStatusIcon(tech.openTicketsCount)}
+                  {getStatusText(tech.openTicketsCount)}
+                </div>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default WorkloadOverview;

--- a/client/src/contexts/NotificationContext.tsx
+++ b/client/src/contexts/NotificationContext.tsx
@@ -4,6 +4,7 @@ import { useAuth } from './AuthContext';
 import { Socket } from "socket.io-client";
 import toast from 'react-hot-toast';
 import { Notification } from '../types';
+import { useLocation } from 'react-router-dom';
 import api from '../services/api';
 
 interface NotificationContextType {
@@ -25,7 +26,9 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [, setSocket] = useState<Socket | null>(null);
 
-  const unreadCount = notifications.filter((n) => !n.read).length;
+  const location = useLocation();
+
+  const unreadCount = notifications.filter((n) => !n.read && !n.isRead).length;
 
   // Fetch initial notifications from DB
   const fetchNotifications = useCallback(async () => {
@@ -97,13 +100,13 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
     return () => {
       newSocket.disconnect();
     };
-  }, [fetchNotifications, user]);
+  }, [fetchNotifications, user, location.pathname]);
 
   const markAsRead = async (id: string) => {
     try {
       await api.patch(`/notifications/${id}/read`);
       setNotifications((prev) =>
-        prev.map((n) => (n._id === id ? { ...n, read: true } : n))
+        prev.map((n) => (n._id === id ? { ...n, read: true, isRead: true } : n))
       );
     } catch (error) {
       console.error('Error marking notification as read:', error);

--- a/client/src/pages/TeamsPage.tsx
+++ b/client/src/pages/TeamsPage.tsx
@@ -7,6 +7,7 @@ import { Plus, Users } from 'lucide-react';
 import TeamModal from '../components/TeamModal';
 import MemberModal from '../components/MemberModal';
 import AssignmentsPanel from '../components/AssignmentsPanel';
+import WorkloadOverview from '../components/WorkloadOverview';
 import Leaderboard from '../components/Leaderboard';
 import Spinner from '../components/Spinner';
 
@@ -129,6 +130,7 @@ const TeamsPage: React.FC = () => {
 
         {/* Assignments Panel & Leaderboard - 1 column */}
         <div className="lg:col-span-1 space-y-6">
+          <WorkloadOverview />
           <AssignmentsPanel />
           <Leaderboard />
         </div>

--- a/client/src/services/requestService.ts
+++ b/client/src/services/requestService.ts
@@ -1,5 +1,5 @@
 import api from './api';
-import { MaintenanceRequest, CreateMaintenanceRequestDto, RequestFilters, PaginatedResponse } from '../types';
+import { MaintenanceRequest, CreateMaintenanceRequestDto, RequestFilters, PaginatedResponse, TechnicianWorkload } from '../types';
 import toast from 'react-hot-toast';
 
 export interface AnalyticsQuery {
@@ -224,5 +224,16 @@ export const requestService = {
     const response = await api.patch(`/requests/${requestId}/reject`);
     toast.success("Financial approval rejected.");
     return response.data;
+  },
+
+  getWorkload: async (): Promise<TechnicianWorkload[]> => {
+    try {
+      const response = await api.get('/requests/workload');
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching technician workload:', error);
+      toast.error('Failed to load workload overview');
+      throw error;
+    }
   }
 };

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -393,3 +393,12 @@ export interface ShiftHandover {
 
 export * from './activity';
 export * from './inventory';
+
+export interface TechnicianWorkload {
+  technicianId: string;
+  technicianName: string;
+  technicianEmail: string;
+  technicianAvatar?: string;
+  openTicketsCount: number;
+  highPriorityCount: number;
+}

--- a/client/src/utils/dateUtils.ts
+++ b/client/src/utils/dateUtils.ts
@@ -1,0 +1,34 @@
+export const getRelativeDateLabel = (dueDate: string | Date): { label: string; colorClass: string } => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const due = new Date(dueDate);
+  due.setHours(0, 0, 0, 0);
+
+  const diffTime = due.getTime() - today.getTime();
+  // Using Math.round helps handle daylight saving time changes gracefully
+  const diffDays = Math.round(diffTime / (1000 * 60 * 60 * 24));
+
+  if (diffDays < 0) {
+    const daysOverdue = Math.abs(diffDays);
+    return {
+      label: `(Overdue by ${daysOverdue} day${daysOverdue === 1 ? '' : 's'})`,
+      colorClass: 'text-rose-500 dark:text-red-400',
+    };
+  } else if (diffDays === 0) {
+    return {
+      label: '(Due today)',
+      colorClass: 'text-amber-600 dark:text-amber-400',
+    };
+  } else if (diffDays === 1) {
+    return {
+      label: '(Due tomorrow)',
+      colorClass: 'text-amber-600 dark:text-amber-400',
+    };
+  } else {
+    return {
+      label: `(In ${diffDays} days)`,
+      colorClass: 'text-slate-500 dark:text-slate-400',
+    };
+  }
+};

--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -2326,3 +2326,55 @@ exports.rejectRequest = async (req, res) => {
     res.status(400).json({ error: error.message });
   }
 };
+
+exports.getWorkload = async (req, res) => {
+  try {
+    const workload = await MaintenanceRequest.aggregate([
+      {
+        $match: {
+          stage: { $in: ['new', 'in-progress'] },
+          assignedToId: { $ne: null }
+        }
+      },
+      {
+        $group: {
+          _id: '$assignedToId',
+          openTicketsCount: { $sum: 1 },
+          highPriorityCount: {
+            $sum: { $cond: [{ $in: ['$priority', ['high', 'urgent']] }, 1, 0] }
+          }
+        }
+      },
+      {
+        $lookup: {
+          from: 'teammembers',
+          localField: '_id',
+          foreignField: '_id',
+          as: 'technician'
+        }
+      },
+      {
+        $unwind: '$technician'
+      },
+      {
+        $project: {
+          _id: 0,
+          technicianId: '$_id',
+          technicianName: '$technician.name',
+          technicianEmail: '$technician.email',
+          technicianAvatar: '$technician.avatar',
+          openTicketsCount: 1,
+          highPriorityCount: 1
+        }
+      },
+      {
+        $sort: { openTicketsCount: -1 }
+      }
+    ]);
+    
+    res.json(workload);
+  } catch (error) {
+    console.error('Workload Aggregation Error:', error);
+    res.status(500).json({ message: 'Failed to fetch technician workload' });
+  }
+};

--- a/server/routes/requests.js
+++ b/server/routes/requests.js
@@ -10,6 +10,7 @@ router.use(protect);
 
 router.get('/', requestController.getAllRequests);
 router.get('/calendar', requestController.getCalendarEvents);
+router.get('/workload', requestController.getWorkload);
 router.get('/:id', requestController.getRequestById);
 router.post('/', requestController.createRequest);
 router.put('/:id', requestController.updateRequest);


### PR DESCRIPTION
## 📌 Pull Request Title

"Ghost" Notifications Reappearing After Navigation (#363)

---

## 🚀 Description

When marking a notification as 'read', the red unread badge would correctly disappear. However, because the application relied on stale React Context state, navigating to a different page caused the red notification badge to instantly resurrect with the old unread count!

---

## 🔗 Related Issue

Closes #363 

---

## 📝 Changes Made

- Route-Aware Notification Context: Relocated the <NotificationProvider> to sit inside the React <Router> hierarchy in App.tsx. Injected location.pathname into the useEffect dependencies so that the context silently deep-syncs with the backend whenever the mechanic navigates to a new page.
- Race Condition Eliminated: Refactored handleNotificationClick in NotificationCenter.tsx to await markAsRead() before triggering the navigate() function. This guarantees the backend has processed the read-receipt before the UI mounts the next view.
- Strict Read Flagging: Updated the unread counters to strictly evaluate both isRead and read boolean flags to handle potential API mismatches, preventing false-positive unread tallies.

---

## 🧪 Testing Performed

- [x] Tested locally
- [x] Templates render correctly on GitHub

---

## 🏷️ NSoC'26 Information

- **Level:** Level 3
- **Points:** 10

---

## ✅ Checklist

- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] This PR does not break existing functionality
- [x] I have added necessary documentation

---

## ⚠️ Important

- PR without issue assignment will be **rejected**
- Missing `NSoC'26` tag will be **requested for update**

---

Thank you for your contribution! 🎉