### PR TITLE
fix: stop propagation on nested modal overlays

### DIFF
--- a/client/src/components/ImageGallery.tsx
+++ b/client/src/components/ImageGallery.tsx
@@ -78,7 +78,7 @@ const ImageGallery: React.FC<ImageGalleryProps> = ({ attachments, onDelete }) =>
       </div>
 
       {selectedImage && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4" onClick={() => setSelectedImage(null)}>
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4" onClick={(e) => { e.stopPropagation(); setSelectedImage(null); }}>
           <div className="relative max-w-4xl max-h-full" onClick={e => e.stopPropagation()}>
             <button 
               className="absolute -top-10 right-0 p-2 text-white/70 hover:text-white transition-colors"

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -25,7 +25,10 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, size = 
         {/* Backdrop */}
         <div
           className="fixed inset-0 transition-opacity bg-black/50 backdrop-blur-sm"
-          onClick={onClose}
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
         ></div>
 
         {/* Modal */}


### PR DESCRIPTION
## 📌 Pull Request Title

Nested Modals Closing Simultaneously on Overlay Click

---

## 🚀 Description

Previously, if a technician opened the RequestModal and then triggered a secondary nested modal (like the Cannibalize Parts modal), clicking the dark gray overlay background would aggressively close both modals at the exact same time, causing the technician to instantly lose all unsaved form data.

---

## 🔗 Related Issue

Closes #373 

---

## 📝 Changes Made

- Stopped Event Propagation: Modified the onClick handler of the bg-black/50 backdrop-blur-sm overlay div inside the shared layout <Modal> wrapper to utilize e.stopPropagation(). Click events are now instantly halted at the top-most modal layer and no longer bubble up the React Portal DOM tree.
- Edge Case Coverage: While scanning the repository, I noticed the ImageGallery overlay implemented a similar custom backdrop without event propagation protection. I proactively applied the same fix there to prevent identical bugs if an image gallery is ever triggered from within another modal.

---

## 🧪 Testing Performed

- [x] Tested locally
- [x] Templates render correctly on GitHub

---

## 🏷️ NSoC'26 Information

- **Level:** Level 3
- **Points:** 10

---

## ✅ Checklist

- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] This PR does not break existing functionality
- [x] I have added necessary documentation

---

## ⚠️ Important

- PR without issue assignment will be **rejected**
- Missing `NSoC'26` tag will be **requested for update**

---

Thank you for your contribution! 🎉