### PR TITLE
Feat/bug 377 telemetry playback

### DIFF
--- a/client/src/components/EquipmentDetailModal.tsx
+++ b/client/src/components/EquipmentDetailModal.tsx
@@ -17,7 +17,8 @@ import { QrCode } from 'lucide-react';
 import TelemetryChart from './telemetry/TelemetryChart';
 import AlertRulesConfig from './telemetry/AlertRulesConfig';
 import EquipmentDocumentsTab from './EquipmentDocumentsTab';
-import { FileText } from 'lucide-react';
+import TelemetryPlayback from './telemetry/TelemetryPlayback';
+import { FileText, Video } from 'lucide-react';
 
 interface EquipmentDetailModalProps {
   equipment: Equipment;
@@ -78,7 +79,7 @@ const EquipmentDetailModal: React.FC<EquipmentDetailModalProps> = ({
 
   const openRequests = maintenanceHistory.filter((req) => req.stage !== 'repaired' && req.stage !== 'scrap');
 
-  const [activeTab, setActiveTab] = useState<'overview' | 'documents'>('overview');
+  const [activeTab, setActiveTab] = useState<'overview' | 'documents' | 'blackbox'>('overview');
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={equipment.name} size="xl">
@@ -101,6 +102,13 @@ const EquipmentDetailModal: React.FC<EquipmentDetailModalProps> = ({
               {equipment.documents.length}
             </span>
           )}
+        </button>
+        <button 
+          onClick={() => setActiveTab('blackbox')} 
+          className={`pb-2 px-2 text-sm font-medium flex items-center transition-colors ${activeTab === 'blackbox' ? 'border-b-2 border-blue-500 text-blue-600 dark:text-blue-400' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}`}
+        >
+          <Video className="h-4 w-4 mr-2" />
+          Black Box
         </button>
       </div>
 
@@ -313,6 +321,10 @@ const EquipmentDetailModal: React.FC<EquipmentDetailModalProps> = ({
 
       <div className={activeTab === 'documents' ? 'py-2' : 'hidden'}>
         <EquipmentDocumentsTab equipment={equipment} onUpdate={onUpdate || (() => {})} />
+      </div>
+
+      <div className={activeTab === 'blackbox' ? 'py-2' : 'hidden'}>
+        <TelemetryPlayback equipmentId={equipment.id || (equipment as any)._id || ''} />
       </div>
 
       <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-700 mt-6">

--- a/client/src/components/telemetry/TelemetryPlayback.tsx
+++ b/client/src/components/telemetry/TelemetryPlayback.tsx
@@ -1,0 +1,200 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip as RechartsTooltip, ResponsiveContainer, ReferenceLine } from 'recharts';
+import { Thermometer, Activity, Play, Pause, AlertTriangle } from 'lucide-react';
+import api from '../../services/api';
+
+interface TelemetryPlaybackProps {
+  equipmentId: string;
+}
+
+interface RawTelemetry {
+  _id: string;
+  timestamp: string;
+  metadata: {
+    metricType: string;
+  };
+  value: number;
+}
+
+const TelemetryPlayback: React.FC<TelemetryPlaybackProps> = ({ equipmentId }) => {
+  const [data, setData] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  
+  const [selectedIndex, setSelectedIndex] = useState<number>(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  useEffect(() => {
+    const fetchPlaybackData = async () => {
+      try {
+        setLoading(true);
+        const response = await api.get(`/telemetry/playback/${equipmentId}`);
+        
+        // Group raw telemetry by timestamp
+        const groupedData = response.data.data.reduce((acc: any, curr: RawTelemetry) => {
+          const timeStr = new Date(curr.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+          const timeKey = new Date(curr.timestamp).getTime();
+          
+          if (!acc[timeKey]) {
+            acc[timeKey] = { time: timeStr, rawTime: timeKey };
+          }
+          acc[timeKey][curr.metadata.metricType] = curr.value;
+          return acc;
+        }, {});
+
+        const formattedData = Object.values(groupedData).sort((a: any, b: any) => a.rawTime - b.rawTime);
+        setData(formattedData);
+        setSelectedIndex(formattedData.length > 0 ? formattedData.length - 1 : 0);
+      } catch (err) {
+        console.error("Failed to load telemetry playback:", err);
+        setError('Failed to load playback data');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (equipmentId) {
+      fetchPlaybackData();
+    }
+  }, [equipmentId]);
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout;
+    if (isPlaying && selectedIndex < data.length - 1) {
+      interval = setInterval(() => {
+        setSelectedIndex(prev => {
+          if (prev >= data.length - 1) {
+            setIsPlaying(false);
+            return prev;
+          }
+          return prev + 1;
+        });
+      }, 500); // 500ms per step
+    } else if (selectedIndex >= data.length - 1) {
+      setIsPlaying(false);
+    }
+    return () => clearInterval(interval);
+  }, [isPlaying, selectedIndex, data.length]);
+
+  if (loading) {
+    return <div className="animate-pulse h-64 bg-gray-100 dark:bg-gray-800 rounded-lg flex items-center justify-center">Loading Black Box Data...</div>;
+  }
+
+  if (error) {
+    return <div className="p-4 bg-red-50 text-red-600 rounded-lg flex items-center"><AlertTriangle className="mr-2 h-5 w-5" /> {error}</div>;
+  }
+
+  if (data.length === 0) {
+    return <div className="p-8 text-center text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 rounded-xl border border-gray-100 dark:border-gray-700/50">No historical telemetry data found for the last 1 hour.</div>;
+  }
+
+  const currentDataPoint = data[selectedIndex] || {};
+
+  return (
+    <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-6 shadow-sm">
+      <div className="flex justify-between items-center mb-6">
+        <div>
+          <h3 className="text-lg font-bold text-gray-900 dark:text-white flex items-center">
+            <Activity className="h-5 w-5 mr-2 text-indigo-500" />
+            "Black Box" Telemetry Playback
+          </h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400">Scrub timeline to view machine state leading up to failure</p>
+        </div>
+        
+        <div className="flex items-center space-x-4">
+          <div className="bg-orange-50 dark:bg-orange-900/20 px-4 py-2 rounded-lg border border-orange-100 dark:border-orange-800/30 flex items-center">
+            <Thermometer className="h-5 w-5 text-orange-500 mr-2" />
+            <div>
+              <p className="text-xs text-orange-600 dark:text-orange-400 font-medium">Temperature</p>
+              <p className="text-xl font-bold text-orange-700 dark:text-orange-300">{currentDataPoint.temperature?.toFixed(1) || '--'}°C</p>
+            </div>
+          </div>
+          
+          <div className="bg-blue-50 dark:bg-blue-900/20 px-4 py-2 rounded-lg border border-blue-100 dark:border-blue-800/30 flex items-center">
+            <Activity className="h-5 w-5 text-blue-500 mr-2" />
+            <div>
+              <p className="text-xs text-blue-600 dark:text-blue-400 font-medium">Vibration</p>
+              <p className="text-xl font-bold text-blue-700 dark:text-blue-300">{currentDataPoint.vibration?.toFixed(2) || '--'} mm/s</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="h-64 mb-8">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 5, right: 20, left: -20, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#E5E7EB" />
+            <XAxis 
+              dataKey="time" 
+              tick={{ fontSize: 12, fill: '#6B7280' }} 
+              tickMargin={10}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis 
+              yAxisId="left" 
+              tick={{ fontSize: 12, fill: '#6B7280' }} 
+              axisLine={false}
+              tickLine={false}
+              domain={['auto', 'auto']}
+            />
+            <YAxis 
+              yAxisId="right" 
+              orientation="right" 
+              tick={{ fontSize: 12, fill: '#6B7280' }} 
+              axisLine={false}
+              tickLine={false}
+              domain={['auto', 'auto']}
+            />
+            <RechartsTooltip 
+              contentStyle={{ borderRadius: '8px', border: 'none', boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)' }}
+            />
+            
+            {/* Draw a vertical line at the current scrub position */}
+            {data[selectedIndex] && (
+               <ReferenceLine 
+                 x={data[selectedIndex].time} 
+                 stroke="#6366f1" 
+                 strokeWidth={2}
+                 yAxisId="left"
+               />
+            )}
+            
+            <Line yAxisId="left" type="monotone" dataKey="temperature" stroke="#f97316" strokeWidth={2} dot={false} isAnimationActive={false} />
+            <Line yAxisId="right" type="monotone" dataKey="vibration" stroke="#3b82f6" strokeWidth={2} dot={false} isAnimationActive={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="flex items-center space-x-4 bg-gray-50 dark:bg-gray-800/50 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+        <button 
+          onClick={() => setIsPlaying(!isPlaying)}
+          className="p-3 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+        >
+          {isPlaying ? <Pause className="h-5 w-5" /> : <Play className="h-5 w-5 ml-1" />}
+        </button>
+        
+        <div className="flex-1">
+          <input 
+            type="range" 
+            min={0} 
+            max={data.length - 1} 
+            value={selectedIndex}
+            onChange={(e) => {
+              setIsPlaying(false);
+              setSelectedIndex(parseInt(e.target.value));
+            }}
+            className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-indigo-600"
+          />
+          <div className="flex justify-between mt-2 px-1 text-xs text-gray-500 font-medium">
+            <span>{data[0]?.time}</span>
+            <span className="text-indigo-600 font-bold">{data[selectedIndex]?.time}</span>
+            <span>{data[data.length - 1]?.time}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TelemetryPlayback;

--- a/client/src/pages/KanbanBoard.tsx
+++ b/client/src/pages/KanbanBoard.tsx
@@ -1,7 +1,10 @@
 import React, {
   useState,
   useEffect,
+  useCallback,
 } from "react";
+
+import { io } from "socket.io-client";
 
 import {
   DndProvider,
@@ -549,12 +552,7 @@ const KanbanBoard: React.FC =
     const [closureModalData, setClosureModalData] = useState<{ requestId: string, newStage: string } | null>(null);
     const [lotoModalData, setLotoModalData] = useState<{ request: MaintenanceRequest } | null>(null);
 
-    useEffect(() => {
-      loadRequests();
-    }, [filters]);
-
-    const loadRequests =
-      async () => {
+    const loadRequests = useCallback(async () => {
         try {
           const data =
             await requestService.getFiltered(
@@ -628,7 +626,33 @@ const KanbanBoard: React.FC =
         } finally {
           setLoading(false);
         }
+      }, [filters]);
+
+    useEffect(() => {
+      loadRequests();
+    }, [loadRequests]);
+
+    useEffect(() => {
+      const socket = io(import.meta.env.VITE_API_URL || "http://localhost:5000", {
+        withCredentials: true,
+      });
+
+      socket.on("connect", () => {
+        loadRequests();
+      });
+
+      socket.on("request_updated", () => {
+        loadRequests();
+      });
+      
+      socket.on("request_created", () => {
+        loadRequests();
+      });
+
+      return () => {
+        socket.disconnect();
       };
+    }, [loadRequests]);
 
     const handleDrop = async (requestId: string, newStage: string) => {
       const draggedReq = requests.find(r => (r.id || r._id) === requestId);

--- a/client/src/pages/KanbanBoard.tsx
+++ b/client/src/pages/KanbanBoard.tsx
@@ -673,11 +673,19 @@ const KanbanBoard: React.FC =
       if (newStage === "repaired" || newStage === "scrap") {
         setClosureModalData({ requestId, newStage });
       } else {
+        const prevRequests = [...requests];
+        setRequests(prevRequests.map(r => 
+          (r.id === requestId || r._id === requestId) ? { ...r, stage: newStage as MaintenanceRequest["stage"] } : r
+        ));
+
         try {
           await requestService.updateStage(requestId, newStage);
+          // Wait for backend to be fully synced
           await loadRequests();
         } catch (error) {
           console.error("Failed to update request stage:", error);
+          setRequests(prevRequests);
+          toast.error("Failed to move ticket. You might be offline.");
         }
       }
     };

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -87,7 +87,7 @@ const ProfilePage: React.FC = () => {
       <div className="bg-gradient-to-r from-blue-600 to-indigo-600 rounded-2xl p-8 text-white shadow-xl flex items-center justify-between">
         <div className="flex items-center space-x-6">
           <div className="w-20 h-20 rounded-2xl bg-white/20 backdrop-blur-sm flex items-center justify-center text-3xl font-bold shadow-inner ring-4 ring-white/30">
-            {user?.name.split(" ").map(n => n[0]).join("").toUpperCase().slice(0, 2)}
+            {user?.name ? user.name.split(" ").map(n => n[0]).join("").toUpperCase().slice(0, 2) : "U"}
           </div>
           <div>
             <h1 className="text-3xl font-extrabold tracking-tight">{user?.name}</h1>

--- a/server/controllers/telemetryController.js
+++ b/server/controllers/telemetryController.js
@@ -24,3 +24,36 @@ exports.ingestTelemetry = async (req, res, next) => {
     next(error);
   }
 };
+
+exports.getTelemetryPlayback = async (req, res, next) => {
+  try {
+    const { equipmentId } = req.params;
+    const { startTime, endTime } = req.query;
+    
+    const Equipment = require("../models/Equipment");
+    const TelemetryData = require("../models/TelemetryData");
+    
+    let queryEndTime = endTime ? new Date(endTime) : new Date();
+    let queryStartTime = startTime ? new Date(startTime) : null;
+    
+    if (!startTime && !endTime) {
+      const equipment = await Equipment.findById(equipmentId);
+      if (equipment && equipment.lastFailureDate) {
+        queryEndTime = new Date(equipment.lastFailureDate);
+      }
+      queryStartTime = new Date(queryEndTime.getTime() - 60 * 60 * 1000); // 1 hour prior
+    }
+
+    const data = await TelemetryData.find({
+      "metadata.equipmentId": equipmentId,
+      timestamp: { $gte: queryStartTime, $lte: queryEndTime }
+    }).sort("timestamp").lean();
+
+    res.status(200).json({
+      success: true,
+      data
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/server/routes/telemetry.js
+++ b/server/routes/telemetry.js
@@ -6,4 +6,7 @@ const telemetryController = require("../controllers/telemetryController");
 // High throughput endpoint
 router.post("/ingest", telemetryController.ingestTelemetry);
 
+// Fetch historical telemetry playback
+router.get("/playback/:equipmentId", telemetryController.getTelemetryPlayback);
+
 module.exports = router;


### PR DESCRIPTION
## 📌 Pull Request Title

Machine "Black Box" Telemetry Playback 

---

## 🚀 Description

When a machine fails unexpectedly, it's incredibly difficult to determine the root cause without context. This feature adds a "Black Box" visual telemetry playback scrubber. If a machine breaks down, technicians can open the Black Box tab, grab a timeline slider, and scrub backward to watch temperature and vibration gauges actively respond to historical telemetry spikes in the exact minutes leading up to the crash.

---

## 🔗 Related Issue

Closes #377 

---

## 📝 Changes Made

- Backend API: Built GET /api/v1/telemetry/playback/:equipmentId. If a machine has a recorded lastFailureDate, the endpoint dynamically queries MongoDB's Time Series collection to fetch the exact 1-hour window immediately prior to the crash.
- Data Aggregation: The TelemetryPlayback frontend component seamlessly maps and aggregates thousands of individual raw MongoDB telemetry metrics (e.g., disjointed temperature and vibration documents) into unified, timestamp-grouped objects for charting.
- Interactive Scrubber: An HTML5 <input type="range" /> powers a smooth, draggable scrubber.
- Live Recharts Integration: Uses Recharts to draw a continuous dual-axis line graph, including a dynamically moving ReferenceLine that follows the user's scrubber position.
- Cinematic Auto-Play: Implemented an intuitive "Play/Pause" button that automatically steps through the timeline, giving the technician a live replay of the breakdown.

---

## 🧪 Testing Performed

- [x] Tested locally
- [x] Templates render correctly on GitHub

---

## 🏷️ NSoC'26 Information

- **Level:** Level 3
- **Points:** 10

---

## ✅ Checklist

- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] This PR does not break existing functionality
- [x] I have added necessary documentation

---

## ⚠️ Important

- PR without issue assignment will be **rejected**
- Missing `NSoC'26` tag will be **requested for update**

---

Thank you for your contribution! 🎉