### PR TITLE
fix: WebSocket Memory/CPU Overload on Telemetry Ingestion (Heartbeat)

### DIFF
--- a/client/src/contexts/NotificationContext.tsx
+++ b/client/src/contexts/NotificationContext.tsx
@@ -54,7 +54,15 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
       auth: { token }
     });
 
-    newSocket.emit('join', user.id);
+    // Re-join rooms on reconnect
+    newSocket.on('connect', () => {
+      newSocket.emit('join', user.id);
+    });
+
+    // Handle custom heartbeat ping/pong
+    newSocket.on('server_ping', () => {
+      newSocket.emit('client_pong');
+    });
 
     // Listen for new notifications
     newSocket.on('notification:new', (notification: Notification) => {

--- a/server/index.js
+++ b/server/index.js
@@ -167,6 +167,12 @@ io.on("connection", (socket) => {
     }
   });
 
+  // Custom Ping/Pong Heartbeat to resolve memory leaks
+  socket.isAlive = true;
+  socket.on("client_pong", () => {
+    socket.isAlive = true;
+  });
+
   socket.on("disconnect", () => {
     // Aggressive garbage collection of custom rooms
     if (socket.rooms && socket.rooms.size > 0) {
@@ -179,6 +185,19 @@ io.on("connection", (socket) => {
     console.log(`❌ User disconnected: ${socket.id}`);
   });
 });
+
+// Periodic Heartbeat check to terminate ghost connections
+setInterval(() => {
+  if (!io || !io.sockets || !io.sockets.sockets) return;
+  io.sockets.sockets.forEach((socket) => {
+    if (socket.isAlive === false) {
+      console.log(`🔌 Heartbeat failed. Force disconnecting ghost socket: ${socket.id}`);
+      return socket.disconnect(true);
+    }
+    socket.isAlive = false;
+    socket.emit("server_ping");
+  });
+}, 30000);
 
 // Admin Audit Tooling: Socket Health Check
 app.get('/api/health/sockets', async (req, res) => {


### PR DESCRIPTION
**Title:** fix: WebSocket Memory/CPU Overload on Telemetry Ingestion (Heartbeat)

## Closes #401 

**Description:**
This PR addresses a critical memory leak in the Node.js server caused by "ghost" socket connections. When clients on poor factory network connections drop off abruptly without sending TCP disconnect frames, the server was indefinitely retaining these socket connections and buffering broadcast data. 

**Changes:**
- Implemented a custom periodic Ping/Pong heartbeat mechanism running every 30 seconds inside `server/index.js`.
- Added aggressive garbage collection: Any socket failing to respond to a `server_ping` within the 30-second window is forcefully disconnected and reaped from memory.
- Updated the React client's `NotificationContext.tsx` to automatically listen for `server_ping` and emit `client_pong`.
- Enforced clean and graceful reconnect strategies on the client. Wrapped `socket.emit('join')` inside a `socket.on('connect')` handler to ensure users are automatically re-registered to their rooms upon network restoration without ever duplicating listeners.