### PR TITLE
feat: QR Code Scanning for Fast Ticket Creation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -54,6 +54,7 @@ function AppContent() {
         <Route path="/admin/rca-builder" element={<RCABuilder />} />
         <Route path="/admin/sync-conflicts" element={<ConflictResolution />} />
         <Route path="/requests" element={<KanbanBoard />} />
+        <Route path="/requests/new" element={<RequestsPage />} />
         <Route path="/financials" element={<FinancialDashboard />} />
         <Route path="/requests-all" element={<RequestsPage />} />
         <Route path="/activity" element={<ActivityPage />} />

--- a/client/src/components/EquipmentDetailModal.tsx
+++ b/client/src/components/EquipmentDetailModal.tsx
@@ -331,7 +331,7 @@ const EquipmentDetailModal: React.FC<EquipmentDetailModalProps> = ({
           <div style={{ display: 'none' }}>
             <QRCodeCanvas
               id="qr-gen"
-              value={`${window.location.origin}/requests?action=newRequest&equipmentId=${equipment.id || (equipment as any)._id}`}
+              value={`${window.location.origin}/requests/new?equipmentId=${equipment.id || (equipment as any)._id}`}
               size={512}
               level={"H"}
               includeMargin={true}

--- a/client/src/components/ResourceManager.tsx
+++ b/client/src/components/ResourceManager.tsx
@@ -290,7 +290,7 @@ const ResourceManager = () => {
                 <div style={{ display: 'none' }}>
                   <QRCodeCanvas
                     id="rm-qr-gen"
-                    value={`${window.location.origin}/requests?action=newRequest&equipmentId=${selectedEquipment._id ?? selectedEquipment.id}`}
+                    value={`${window.location.origin}/requests/new?equipmentId=${selectedEquipment._id ?? selectedEquipment.id}`}
                     size={512}
                     level={"H"}
                     includeMargin={true}

--- a/client/src/pages/RequestsPage.tsx
+++ b/client/src/pages/RequestsPage.tsx
@@ -12,7 +12,9 @@ const RequestsPage = () => {
   const [editRequestId, setEditRequestId] = useState<string | undefined>();
 
   useEffect(() => {
-    if (searchParams.get('action') === 'newRequest') {
+    const isNewRequestRoute = window.location.pathname === '/requests/new';
+    
+    if (searchParams.get('action') === 'newRequest' || isNewRequestRoute) {
       const equipmentId = searchParams.get('equipmentId');
       if (equipmentId) {
         setInitialEquipmentId(equipmentId);
@@ -20,10 +22,15 @@ const RequestsPage = () => {
       setIsModalOpen(true);
       
       // Clean up the URL to prevent reopening on refresh
-      const newParams = new URLSearchParams(searchParams);
-      newParams.delete('action');
-      newParams.delete('equipmentId');
-      setSearchParams(newParams, { replace: true });
+      if (searchParams.get('action') === 'newRequest') {
+        const newParams = new URLSearchParams(searchParams);
+        newParams.delete('action');
+        newParams.delete('equipmentId');
+        setSearchParams(newParams, { replace: true });
+      } else if (isNewRequestRoute) {
+        // Redirect to standard requests page silently so it doesn't reopen modal on refresh
+        window.history.replaceState(null, '', '/requests-all');
+      }
     }
   }, [searchParams, setSearchParams]);
 


### PR DESCRIPTION
**Title:** feat: QR Code Scanning for Fast Ticket Creation

## Closes #411 

**Description:**
This PR introduces a fast and seamless method for operators on the factory floor to report breakdowns instantly. By scanning a QR code taped to physical machines, workers bypass manual search entirely.

**Changes:**
- Adjusted the `<QRCodeCanvas />` configurations within `EquipmentDetailModal` and `ResourceManager` to generate clean, printable QR codes.
- The QR codes embed a direct URL link structured as `/requests/new?equipmentId={id}`.
- Added a robust route configuration in `App.tsx` that correctly captures `/requests/new`.
- Updated `RequestsPage.tsx` to automatically listen for the `/requests/new` route or the legacy `action=newRequest` parameter. When detected, it intercepts the query, immediately opens the `RequestModal`, pre-selects the correct `equipmentId`, and silently cleans up the URL history so the modal doesn't re-trigger on refresh.