### PR TITLE
feat: Maintenance Request Cloning

### DIFF
--- a/client/src/components/DetailedRequestsTable.tsx
+++ b/client/src/components/DetailedRequestsTable.tsx
@@ -23,13 +23,15 @@ import {
   ChevronUp,
   Edit2,
   Eye,
+  Copy,
 } from "lucide-react";
 
 interface DetailedRequestsTableProps {
   onEdit?: (id: string) => void;
+  onClone?: (id: string) => void;
 }
 
-const DetailedRequestsTable: React.FC<DetailedRequestsTableProps> = ({ onEdit }) => {
+const DetailedRequestsTable: React.FC<DetailedRequestsTableProps> = ({ onEdit, onClone }) => {
   const [requests, setRequests] = useState<MaintenanceRequest[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -375,6 +377,19 @@ const DetailedRequestsTable: React.FC<DetailedRequestsTableProps> = ({ onEdit })
                        >
                          <Edit2 className="w-4 h-4 mr-1" />
                          Edit
+                       </button>
+                    )}
+                    {onClone && (
+                       <button 
+                         onClick={(e) => {
+                           e.stopPropagation();
+                           onClone(request.id || request._id || '');
+                         }}
+                         className="flex items-center text-amber-600 dark:text-amber-400 hover:text-amber-900 dark:hover:text-amber-300 font-medium transition-colors"
+                         title="Clone Request"
+                       >
+                         <Copy className="w-4 h-4 mr-1" />
+                         Clone
                        </button>
                     )}
                     <button 

--- a/client/src/components/RequestModal.tsx
+++ b/client/src/components/RequestModal.tsx
@@ -36,6 +36,7 @@ interface RequestModalProps {
   initialType?: 'corrective' | 'preventive';
   initialEquipmentId?: string;
   editRequestId?: string;
+  cloneRequestId?: string;
 }
 
 const RequestModal: React.FC<RequestModalProps> = ({
@@ -46,6 +47,7 @@ const RequestModal: React.FC<RequestModalProps> = ({
   initialType = 'corrective',
   initialEquipmentId,
   editRequestId,
+  cloneRequestId,
 }) => {
   const { user } = useAuth();
   const [activeTab, setActiveTab] = useState<'details' | 'comments' | 'loto' | 'tools' | 'vendor'>('details');
@@ -233,10 +235,38 @@ const RequestModal: React.FC<RequestModalProps> = ({
           console.error(err);
           setLoadingPredictions(false);
         });
+    } else if (isOpen && cloneRequestId) {
+      requestService.getById(cloneRequestId)
+        .then(req => {
+          setExistingRequest(null);
+          // Auto-fill form data for cloning, stripping out state/ids
+          setFormData({
+            subject: `[CLONE] ${req.subject || ''}`,
+            description: req.description || '',
+            type: req.type,
+            priority: req.priority,
+            scheduledDate: formatDateForInput(new Date()),
+            equipmentId: typeof req.equipmentId === 'object' ? (req.equipmentId as any)._id : req.equipmentId || '',
+            teamId: typeof req.teamId === 'object' ? (req.teamId as any)._id : req.teamId || '',
+            assignedToId: '', // Reset assignment
+            checklist: req.checklist || [],
+            requiredCertifications: req.requiredCertifications || [],
+            expectedVendorQuote: req.expectedVendorQuote || 0,
+            requiredSkills: req.requiredSkills || [],
+          });
+          const eqId = typeof req.equipmentId === 'object' ? (req.equipmentId as any)._id : req.equipmentId;
+          if (eqId) {
+             handleEquipmentChange(eqId);
+          }
+        })
+        .catch(err => {
+          console.error('Failed to fetch request for cloning:', err);
+          toast.error('Failed to load request for cloning');
+        });
     } else {
       setExistingRequest(null);
     }
-  }, [isOpen, editRequestId]);
+  }, [isOpen, editRequestId, cloneRequestId]);
 
   useEffect(() => {
     if (existingRequest?.equipment?.category) {
@@ -417,6 +447,7 @@ const RequestModal: React.FC<RequestModalProps> = ({
           partsUsed: selectedParts.filter(p => p.partId && p.quantityUsed > 0),
           requiredParts: requiredParts.filter(p => p.partId && p.quantityNeeded > 0),
           expectedVendorQuote: formData.expectedVendorQuote,
+          clonedFromId: cloneRequestId,
         });
 
         if (attachments.length > 0 && newRequest._id) {

--- a/client/src/pages/KanbanBoard.tsx
+++ b/client/src/pages/KanbanBoard.tsx
@@ -697,7 +697,7 @@ const KanbanBoard: React.FC =
           let lat: number | undefined;
           let lng: number | undefined;
 
-          if (newStage === "in-progress" && request.equipment?.riskLevel === 'High Risk') {
+          if (newStage === "in-progress" && request?.equipment?.riskLevel === 'High Risk') {
             try {
               const position = await getCurrentPosition();
               lat = position.latitude;

--- a/client/src/pages/RequestsPage.tsx
+++ b/client/src/pages/RequestsPage.tsx
@@ -10,6 +10,7 @@ const RequestsPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [initialEquipmentId, setInitialEquipmentId] = useState<string | undefined>();
   const [editRequestId, setEditRequestId] = useState<string | undefined>();
+  const [cloneRequestId, setCloneRequestId] = useState<string | undefined>();
 
   useEffect(() => {
     const isNewRequestRoute = window.location.pathname === '/requests/new';
@@ -38,6 +39,7 @@ const RequestsPage = () => {
     setIsModalOpen(false);
     setInitialEquipmentId(undefined);
     setEditRequestId(undefined);
+    setCloneRequestId(undefined);
   };
 
   return (
@@ -47,7 +49,7 @@ const RequestsPage = () => {
           <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Maintenance Requests</h2>
           <p className="text-gray-600 dark:text-gray-400 mt-1">Manage all maintenance requests and their status</p>
         </div>
-        <Button variant="primary" onClick={() => { setEditRequestId(undefined); setIsModalOpen(true); }}>
+        <Button variant="primary" onClick={() => { setEditRequestId(undefined); setCloneRequestId(undefined); setIsModalOpen(true); }}>
           <Plus className="w-4 h-4 mr-2" />
           New Request
         </Button>
@@ -55,7 +57,13 @@ const RequestsPage = () => {
 
       <DetailedRequestsTable 
         onEdit={(id) => {
+          setCloneRequestId(undefined);
           setEditRequestId(id);
+          setIsModalOpen(true);
+        }}
+        onClone={(id) => {
+          setEditRequestId(undefined);
+          setCloneRequestId(id);
           setIsModalOpen(true);
         }}
       />
@@ -65,6 +73,7 @@ const RequestsPage = () => {
         onClose={handleCloseModal}
         initialEquipmentId={initialEquipmentId}
         editRequestId={editRequestId}
+        cloneRequestId={cloneRequestId}
         onSuccess={() => {
           handleCloseModal();
           // Reload requests

--- a/client/src/services/requestService.ts
+++ b/client/src/services/requestService.ts
@@ -83,15 +83,14 @@ export const requestService = {
     stage: string,
     partsCost?: number,
     laborCost?: number,
-    __v?: number
+    __v?: number,
     latitude?: number,
     longitude?: number
   ): Promise<MaintenanceRequest> => {
     try {
       const response = await api.patch(
         `/requests/${id}/stage`,
-        { stage, partsCost, laborCost, __v }
-        { stage, partsCost, laborCost, latitude, longitude }
+        { stage, partsCost, laborCost, __v, latitude, longitude }
       );
       toast.success("Request stage updated");
       return response.data;
@@ -248,6 +247,7 @@ export const requestService = {
     const response = await api.post(`/requests/${requestId}/escalate`, data);
     toast.success('Ticket escalated to vendor successfully');
     return response.data.request;
+  },
 
   getRootCauseAnalytics: async (): Promise<any> => {
     const response = await api.get('/analytics/root-cause');

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -105,6 +105,7 @@ export interface TeamMember {
 
 export interface MaintenanceRequest {
   _id?: string;
+  __v?: number;
   id: string;
   requestNumber: string;
   subject: string;
@@ -242,6 +243,7 @@ export interface CreateMaintenanceRequestDto {
   rootCause?: string;
   rcaNodeId?: string;
   expectedVendorQuote?: number;
+  clonedFromId?: string;
 }
 
 export interface Notification {

--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -114,6 +114,7 @@ const sanitizeBody = (body) => {
     "teamId",
     "assignedToId",
     "createdById",
+    "clonedFromId",
   ];
   objectIdFields.forEach((f) => {
     if (cleaned[f] === "" || cleaned[f] === null) delete cleaned[f];

--- a/server/models/MaintenanceRequest.js
+++ b/server/models/MaintenanceRequest.js
@@ -107,6 +107,7 @@ const MaintenanceRequestSchema = new Schema({
   downtimeDurationHours: { type: Number, default: 0 },
   totalDowntimeCost: { type: Number, default: 0 },
   syncId: { type: String, default: null }, // UUID from offline device to prevent replay attacks or resolve conflicts
+  clonedFromId: { type: Schema.Types.ObjectId, ref: 'MaintenanceRequest' },
   vendorEscalation: {
     isEscalated: { type: Boolean, default: false },
     vendorEmail: { type: String },


### PR DESCRIPTION
# PR Message: feat: Maintenance Request Cloning

## Closes #425 

### 🎯 Objective
Empower the maintenance team to rapidly duplicate similar or recurring work orders without manually re-entering repetitive data, significantly saving time.

### 🛠️ Changes Made
- **UI Integration:** Added a new "Clone" action button inside the `DetailedRequestsTable` (next to Edit).
- **State Management:** Extended `RequestsPage.tsx` and `RequestModal.tsx` to handle a `cloneRequestId` state, decoupling it from standard edits.
- **Prefilling Logic:** The modal intercepts `cloneRequestId`, fetches the target request, strips out instance-specific properties (like original assignment, execution dates, and internal IDs), and prepopulates the form. The subject is smartly prefixed with `[CLONE]`.
- **Backend Traceability:** Added `clonedFromId` to the `MaintenanceRequest` schema and passed it successfully during request creation to retain an audit trail of duplicated tickets.
- **Typescript Alignment:** Resolved underlying TS issues and ensured `CreateMaintenanceRequestDto` supports the new trace field.

### 📈 Impact
Technicians and managers can now instantly recreate extensive checklists, required parts, and descriptions for recurring faults with a single click, ensuring consistency and drastically reducing administrative friction.
