### PR TITLE
feat: Technician Fatigue Monitoring

### DIFF
--- a/client/src/components/RequestModal.tsx
+++ b/client/src/components/RequestModal.tsx
@@ -995,10 +995,12 @@ const RequestModal: React.FC<RequestModalProps> = ({
                 let workloadBadge = "🟢 0-2 (Avail)";
                 if (count >= 6) workloadBadge = `🔴 ${count} (Overloaded)`;
                 else if (count >= 3) workloadBadge = `🟠 ${count} (Busy)`;
+                
+                const fatigueWarning = workload?.isFatigued ? " [⚠️ FATIGUED]" : "";
 
                 return (
                   <option key={memberId} value={memberId}>
-                    {member.name} {certificationStatus ? `(${certificationStatus})` : ""} - {workloadBadge}
+                    {member.name} - {workloadBadge}{certificationStatus}{fatigueWarning}
                   </option>
                 );
             })}

--- a/client/src/pages/KanbanBoard.tsx
+++ b/client/src/pages/KanbanBoard.tsx
@@ -697,7 +697,7 @@ const KanbanBoard: React.FC =
           let lat: number | undefined;
           let lng: number | undefined;
 
-          if (newStage === "in-progress" && request.equipment?.riskLevel === 'High Risk') {
+          if (newStage === "in-progress" && request?.equipment?.riskLevel === 'High Risk') {
             try {
               const position = await getCurrentPosition();
               lat = position.latitude;

--- a/client/src/services/requestService.ts
+++ b/client/src/services/requestService.ts
@@ -83,15 +83,14 @@ export const requestService = {
     stage: string,
     partsCost?: number,
     laborCost?: number,
-    __v?: number
+    __v?: number,
     latitude?: number,
     longitude?: number
   ): Promise<MaintenanceRequest> => {
     try {
       const response = await api.patch(
         `/requests/${id}/stage`,
-        { stage, partsCost, laborCost, __v }
-        { stage, partsCost, laborCost, latitude, longitude }
+        { stage, partsCost, laborCost, __v, latitude, longitude }
       );
       toast.success("Request stage updated");
       return response.data;
@@ -248,6 +247,7 @@ export const requestService = {
     const response = await api.post(`/requests/${requestId}/escalate`, data);
     toast.success('Ticket escalated to vendor successfully');
     return response.data.request;
+  },
 
   getRootCauseAnalytics: async (): Promise<any> => {
     const response = await api.get('/analytics/root-cause');

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -105,6 +105,7 @@ export interface TeamMember {
 
 export interface MaintenanceRequest {
   _id?: string;
+  __v?: number;
   id: string;
   requestNumber: string;
   subject: string;
@@ -414,4 +415,5 @@ export interface TechnicianWorkload {
   technicianAvatar?: string;
   openTicketsCount: number;
   highPriorityCount: number;
+  isFatigued?: boolean;
 }

--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -2588,7 +2588,8 @@ exports.getWorkload = async (req, res) => {
           technicianEmail: '$technician.email',
           technicianAvatar: '$technician.avatar',
           openTicketsCount: 1,
-          highPriorityCount: 1
+          highPriorityCount: 1,
+          isFatigued: { $gte: ['$openTicketsCount', 4] }
         }
       },
       {


### PR DESCRIPTION
# PR Message: feat: Technician Fatigue Monitoring

## Closes #426 

### 🎯 Objective
Prevent technician burnout, improve safety compliance, and distribute load evenly by flagging technicians who are overloaded with active tasks during manual and smart assignments.

### 🛠️ Changes Made
- **Workload Aggregation:** Modified `getWorkload` in `server/controllers/requestController.js` to dynamically compute an `isFatigued` boolean when a technician hits 4+ active or in-progress tickets.
- **Frontend Types:** Added `isFatigued` to the `TechnicianWorkload` interface inside `client/src/types/index.ts`.
- **Assignment UI Warnings:** Enhanced `RequestModal.tsx` so that when a manager attempts to manually assign a request, any technician exceeding the safe capacity threshold is explicitly tagged with a `[⚠️ FATIGUED]` warning right in the dropdown.
- **Speed & Stability:** Maintained the existing 5-task hard cap (`MAX_WORKLOAD = 5`) inside the `smartAssignInternal` auto-routing logic while giving managers visual insight prior to hitting the blocker.

### 📈 Impact
Managers are now visually warned before assigning hazardous or general tasks to exhausted technicians, increasing safety (especially for LOTO or High-Risk tickets) and avoiding bottlenecks where one technician hoards tickets while others remain idle.
