### PR TITLE
feat: Request Dependency Chain (Blockers)

### DIFF
--- a/client/src/components/DetailedRequestsTable.tsx
+++ b/client/src/components/DetailedRequestsTable.tsx
@@ -344,6 +344,11 @@ const DetailedRequestsTable: React.FC<DetailedRequestsTableProps> = ({ onEdit, o
                         Pending {request.approvalStatus === 'pending_tier1' ? 'Manager' : 'Admin'}
                       </div>
                     )}
+                    {request.blockedByIds && request.blockedByIds.length > 0 && request.stage !== 'repaired' && request.stage !== 'scrap' && (
+                      <div className="mt-1 text-[10px] font-bold text-red-600 bg-red-50 border border-red-200 px-1.5 py-0.5 rounded-sm inline-flex items-center">
+                        🔗 BLOCKED ({request.blockedByIds.length})
+                      </div>
+                    )}
                   </td>
 
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-200">

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -185,6 +185,7 @@ export interface MaintenanceRequest {
     comments?: string;
     status?: string;
   }[];
+  blockedByIds?: string[];
   createdAt?: string;
   updatedAt?: string;
 }
@@ -244,6 +245,7 @@ export interface CreateMaintenanceRequestDto {
   rcaNodeId?: string;
   expectedVendorQuote?: number;
   clonedFromId?: string;
+  blockedByIds?: string[];
 }
 
 export interface Notification {

--- a/server/controllers/requestController.js
+++ b/server/controllers/requestController.js
@@ -1045,6 +1045,18 @@ exports.updateRequestStage = async (req, res) => {
        return res.status(400).json({ error: "Cannot start an in-progress ticket while blocked awaiting parts." });
     }
 
+    // DEPENDENCY CHAIN GUARD: prevent starting work if blocking requests are still open
+    if (stage === 'in-progress' && request.blockedByIds && request.blockedByIds.length > 0) {
+      const blockers = await MaintenanceRequest.find({
+        _id: { $in: request.blockedByIds },
+        stage: { $nin: ['repaired', 'scrap'] }
+      }).select('requestNumber subject');
+      if (blockers.length > 0) {
+        const blockerList = blockers.map(b => `${b.requestNumber}: ${b.subject}`).join(', ');
+        return res.status(400).json({ error: `Blocked by unresolved dependencies: ${blockerList}` });
+      }
+    }
+
     // GEO-FENCING VALIDATION
     if (stage === 'in-progress' && request.equipment && request.equipment.riskLevel === 'High Risk') {
       if (latitude === undefined || longitude === undefined) {

--- a/server/models/MaintenanceRequest.js
+++ b/server/models/MaintenanceRequest.js
@@ -117,7 +117,8 @@ const MaintenanceRequestSchema = new Schema({
     tokenExpiresAt: { type: Date }
   },
   rootCause: { type: String }, // Used by the RCA logic tree wizard
-  rcaNodeId: { type: Schema.Types.ObjectId, ref: 'DiagnosticNode' } // Final leaf node of the RCA tree
+  rcaNodeId: { type: Schema.Types.ObjectId, ref: 'DiagnosticNode' }, // Final leaf node of the RCA tree
+  blockedByIds: [{ type: Schema.Types.ObjectId, ref: 'MaintenanceRequest' }] // Dependency chain: this request is blocked until these are completed
 }, { timestamps: true });
 
 MaintenanceRequestSchema.virtual('equipment', {


### PR DESCRIPTION
# PR Message: feat: Request Dependency Chain (Blockers)


## Closes #427 


### 🎯 Objective
Enable work order dependency tracking so that a request cannot be started until all its prerequisite/blocking requests are completed.

### 🛠️ Changes Made
- **Schema:** Added `blockedByIds` (array of ObjectId refs to MaintenanceRequest) to `MaintenanceRequest.js`.
- **Stage Guard:** Added a dependency chain check in `updateRequestStage` — when moving to `in-progress`, the system queries all `blockedByIds` and rejects the transition if any are still open, returning the specific blocker request numbers.
- **Types:** Added `blockedByIds` to both `MaintenanceRequest` and `CreateMaintenanceRequestDto` interfaces.
- **UI Indicator:** Added a `🔗 BLOCKED (N)` red badge in the `DetailedRequestsTable` stage column for any request with unresolved dependencies.

### 📈 Impact
