### PR TITLE
feat: Equipment Warranty Expiration Notifications

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,7 @@ const { startOverdueChecker } = require("./jobs/overdueChecker");
 const { startSlaChecker } = require("./jobs/slaChecker");
 const { syncDatabase } = require("./models");
 const { startCertificationChecker } = require("./jobs/certificationChecker");
+const { startWarrantyChecker } = require("./jobs/warrantyChecker");
 const swaggerSpec = require("./config/swagger");
 const passport = require("./config/passport");
 
@@ -363,6 +364,7 @@ const startServer = async () => {
     // Start SLA tracker cron job
     startSlaChecker(io);
     startCertificationChecker();
+    startWarrantyChecker();
 
     const { startHealthScoreCron } = require('./cron/healthScoreCron');
     const { startPreventiveSchedulerCron } = require('./cron/preventiveSchedulerCron');

--- a/server/jobs/warrantyChecker.js
+++ b/server/jobs/warrantyChecker.js
@@ -1,0 +1,66 @@
+const cron = require('node-cron');
+const { Equipment } = require('../models');
+const NotificationService = require('../services/notificationService');
+
+const startWarrantyChecker = () => {
+  // Runs daily at 7:00 AM
+  cron.schedule('0 7 * * *', async () => {
+    try {
+      const now = new Date();
+      const thirtyDaysFromNow = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+      // Find equipment with warranty expiring within 30 days that hasn't been notified
+      const expiringEquipment = await Equipment.find({
+        warrantyExpiry: { $gte: now, $lte: thirtyDaysFromNow },
+        warrantyNotified: { $ne: true },
+        status: { $ne: 'Scrapped' }
+      });
+
+      for (const equip of expiringEquipment) {
+        const daysLeft = Math.ceil((new Date(equip.warrantyExpiry) - now) / (1000 * 60 * 60 * 24));
+
+        await NotificationService.createAndEmit({
+          title: '⏰ Warranty Expiring Soon',
+          message: `Equipment "${equip.name}" (${equip.serialNumber || 'N/A'}) warranty expires in ${daysLeft} day(s) on ${new Date(equip.warrantyExpiry).toLocaleDateString()}.`,
+          type: 'equipment_status',
+          link: '/equipment',
+          relatedEquipmentId: equip._id,
+        });
+
+        equip.warrantyNotified = true;
+        await equip.save();
+      }
+
+      // Also check already-expired warranties
+      const expiredEquipment = await Equipment.find({
+        warrantyExpiry: { $lt: now },
+        warrantyExpiredNotified: { $ne: true },
+        status: { $ne: 'Scrapped' }
+      });
+
+      for (const equip of expiredEquipment) {
+        await NotificationService.createAndEmit({
+          title: '🚨 Warranty Expired',
+          message: `Equipment "${equip.name}" (${equip.serialNumber || 'N/A'}) warranty has expired as of ${new Date(equip.warrantyExpiry).toLocaleDateString()}. Future repairs will not be covered.`,
+          type: 'equipment_status',
+          link: '/equipment',
+          relatedEquipmentId: equip._id,
+        });
+
+        equip.warrantyExpiredNotified = true;
+        await equip.save();
+      }
+
+      const total = expiringEquipment.length + expiredEquipment.length;
+      if (total > 0) {
+        console.log(`Warranty checker: notified for ${total} equipment item(s).`);
+      }
+    } catch (error) {
+      console.error('Warranty checker error:', error.message);
+    }
+  });
+
+  console.log('Warranty expiration checker cron job started.');
+};
+
+module.exports = { startWarrantyChecker };

--- a/server/models/Equipment.js
+++ b/server/models/Equipment.js
@@ -13,6 +13,8 @@ const EquipmentSchema = new Schema({
   expectedLifespanYears: { type: Number, default: 5 },
   salvageValue: { type: Number, default: 0 },
   warrantyExpiry: { type: Date },
+  warrantyNotified: { type: Boolean, default: false },
+  warrantyExpiredNotified: { type: Boolean, default: false },
   manufacturer: { type: String },
   model: { type: String },
   status: { type: String, enum: ['active', 'inactive', 'scrapped', 'under-maintenance'], default: 'active' },


### PR DESCRIPTION
# PR Message: feat: Equipment Warranty Expiration Notifications

## Closes #428 

### 🎯 Objective
Proactively alert maintenance managers when equipment warranties are about to expire or have already expired, preventing costly out-of-warranty repair surprises.

### 🛠️ Changes Made
- **New Cron Job:** Created `server/jobs/warrantyChecker.js` — runs daily at 7 AM, queries all non-scrapped equipment with warranties expiring within 30 days or already expired.
- **Dual Notification Tiers:** Sends "⏰ Warranty Expiring Soon" (with days remaining) for upcoming expirations, and "🚨 Warranty Expired" for already-lapsed warranties.
- **Idempotent Flags:** Added `warrantyNotified` and `warrantyExpiredNotified` boolean fields to `Equipment.js` schema to prevent duplicate notifications.
- **Server Registration:** Imported and started the checker in `server/index.js` alongside existing cron jobs.

### 📈 Impact
Managers now receive automatic, timely alerts to renew warranties or schedule covered repairs before coverage lapses, directly reducing unplanned maintenance costs.
