### PR TITLE
Bug Fix: Kanban Optimistic Drag-and-Drop Desyncs on Network Failure (#439)

### DIFF
--- a/client/src/pages/KanbanBoard.tsx
+++ b/client/src/pages/KanbanBoard.tsx
@@ -693,7 +693,7 @@ const KanbanBoard: React.FC =
 
         try {
           const request = requests.find((r) => r.id === requestId || r._id === requestId);
-          await requestService.updateStage(requestId, newStage, undefined, undefined, request?.__v);
+          
           let lat: number | undefined;
           let lng: number | undefined;
 
@@ -709,7 +709,12 @@ const KanbanBoard: React.FC =
             }
           }
 
-          await requestService.updateStage(requestId, newStage, undefined, undefined, lat, lng);
+          const response = await requestService.updateStage(requestId, newStage, undefined, undefined, request?.__v, lat, lng);
+          
+          if ((response as any)?.offline) {
+             throw new Error("Network Error: Failed to move ticket");
+          }
+
           // Wait for backend to be fully synced
           await loadRequests();
         } catch (error: any) {
@@ -718,7 +723,7 @@ const KanbanBoard: React.FC =
           if (error.response?.status === 403) {
             toast.error(error.response.data.error || "Security Violation");
           } else {
-            toast.error("Failed to move ticket. You might be offline.");
+            toast.error("Network Error: Failed to move ticket");
           }
         }
       }

--- a/client/src/pages/KanbanBoard.tsx
+++ b/client/src/pages/KanbanBoard.tsx
@@ -925,4 +925,4 @@ const KanbanBoard: React.FC =
     );
   };
 
-export default KanbanBoard;
+export default KanbanBoard;// kanban bug fix applied


### PR DESCRIPTION
# 🐛 Bug Fix: Kanban Optimistic Drag-and-Drop Desyncs on Network Failure (#439)

## 🚀 Description
This PR resolves a critical flaw in the React Kanban board where drag-and-drop operations were failing silently in the background when the user was offline, leaving the UI permanently desynced from the database until the next page reload. 

## Closes #439 

## 🛠️ Root Cause
1. **Redundant API Calls**: The `try` block in `handleDrop` was erroneously executing the `updateStage` API call twice under certain conditions, increasing the surface area for failure.
2. **Offline Interceptor Conflict**: The global `api.ts` interceptor elegantly intercepts offline POST/PATCH requests, saves them to IndexedDB, and returns a synthetic `{ success: true, offline: true }` payload. Because it returned success rather than a `Network Error`, the Kanban Board's `try/catch` block never realized the primary transaction failed to reach the server, meaning it never executed the `setRequests(prevRequests)` rollback logic!

## ✨ The Fix
1. **Consolidated API Calls**: Refactored `handleDrop` in `KanbanBoard.tsx` to precisely execute the `updateStage` call only once.
2. **Offline Guard**: Explicitly added an `if (response?.offline) throw new Error("Network Error");` guard inside the `try` block. This ensures that if the system drops to offline execution during drag-and-drop, it forcefully triggers the `catch` block.
3. **Graceful UI Rollback**: The `catch` block now correctly executes `setRequests(prevRequests)` to instantly snap the UI back to reality, and fires a red `toast.error` to alert the user.

## 🧪 Verification & Acceptance Criteria
- [x] Captured original state using `const prevRequests = [...requests]`
- [x] Validated `try/catch` encapsulation around `updateStage` 
- [x] Reverted the state natively using `setRequests(prevRequests)` upon offline network interception
- [x] Added `toast.error("Network Error: Failed to move ticket")` warning

## 🏷️ NSoC'26 Information
- **Level**: Level 3
- **Points**: 10
- **Resolves**: #439