### PR TITLE
fix: remove hardcoded localhost URLs from React client

### DIFF
--- a/client/src/components/EquipmentDocumentsTab.tsx
+++ b/client/src/components/EquipmentDocumentsTab.tsx
@@ -173,7 +173,7 @@ const EquipmentDocumentsTab: React.FC<EquipmentDocumentsTabProps> = ({ equipment
                 
                 <div className="mt-auto flex justify-between items-center pt-3 border-t border-gray-100 dark:border-gray-700/50">
                   <a 
-                    href={doc.fileUrl.startsWith('http') ? doc.fileUrl : `http://localhost:5000${doc.fileUrl}`} 
+                    href={doc.fileUrl.startsWith('http') ? doc.fileUrl : `${import.meta.env.VITE_API_URL?.replace('/api/v1', '') || ''}${doc.fileUrl}`}
                     target="_blank" 
                     rel="noopener noreferrer"
                     className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 text-sm font-medium flex items-center"

--- a/client/src/components/ImageGallery.tsx
+++ b/client/src/components/ImageGallery.tsx
@@ -21,8 +21,9 @@ const ImageGallery: React.FC<ImageGalleryProps> = ({ attachments, onDelete }) =>
   }
 
   const getFullUrl = (url: string) => {
-    if (url.startsWith('http')) return url;
-    return `http://localhost:5000${url}`;
+    if (url.startsWith('http') || url.startsWith('blob:')) return url;
+    const baseUrl = import.meta.env.VITE_API_URL?.replace('/api/v1', '') || '';
+    return `${baseUrl}${url}`;
   };
 
   return (

--- a/client/src/components/NotificationDropdown.tsx
+++ b/client/src/components/NotificationDropdown.tsx
@@ -11,7 +11,7 @@ import {
 } from '../services/notificationService';
 
 const SOCKET_URL = import.meta.env.VITE_API_URL?.replace('/api', '')
-  || 'http://localhost:5000';
+  || '';
 
 interface NotificationDropdownProps {
   userId: string;

--- a/client/src/components/RequestModal.tsx
+++ b/client/src/components/RequestModal.tsx
@@ -1418,7 +1418,7 @@ const RequestModal: React.FC<RequestModalProps> = ({
                     <h4 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Proof of Lockout</h4>
                     <div className="rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-900 aspect-video relative flex items-center justify-center">
                       <img 
-                        src={existingRequest.lotoAudit.proofImageUrl.startsWith('http') ? existingRequest.lotoAudit.proofImageUrl : `http://localhost:5000${existingRequest.lotoAudit.proofImageUrl}`} 
+                        src={existingRequest.lotoAudit.proofImageUrl.startsWith('http') ? existingRequest.lotoAudit.proofImageUrl : `${import.meta.env.VITE_API_URL?.replace('/api/v1', '') || ''}${existingRequest.lotoAudit.proofImageUrl}`} 
                         alt="LOTO Proof" 
                         className="max-w-full max-h-full object-contain"
                       />

--- a/client/src/components/RequestToolsTab.tsx
+++ b/client/src/components/RequestToolsTab.tsx
@@ -8,7 +8,7 @@ import { Wrench, Loader2 } from 'lucide-react';
 import Spinner from './Spinner';
 import { io } from 'socket.io-client';
 
-const SOCKET_URL = import.meta.env.VITE_API_URL?.replace('/api/v1', '') || 'http://localhost:5000';
+const SOCKET_URL = import.meta.env.VITE_API_URL?.replace('/api/v1', '') || '';
 
 interface RequestToolsTabProps {
   requestRecord: MaintenanceRequest;

--- a/client/src/components/TicketComments.tsx
+++ b/client/src/components/TicketComments.tsx
@@ -9,7 +9,7 @@ interface TicketCommentsProps {
   currentUser: { _id?: string; id?: string; name: string } | null;
 }
 
-const SOCKET_URL = import.meta.env.VITE_API_URL?.replace('/api/v1', '') || 'http://localhost:5000';
+const SOCKET_URL = import.meta.env.VITE_API_URL?.replace('/api/v1', '') || '';
 
 // Custom sleek, glassmorphic Audio Player component
 const AudioPlayer: React.FC<{ src: string; duration?: number; isMe?: boolean }> = ({ src, duration, isMe }) => {

--- a/client/src/components/telemetry/TelemetryChart.tsx
+++ b/client/src/components/telemetry/TelemetryChart.tsx
@@ -29,7 +29,7 @@ const TelemetryChart: React.FC<TelemetryChartProps> = ({ equipmentId, metricType
     if (!user) return;
 
     const token = localStorage.getItem('gearguard_token');
-    const newSocket = io(import.meta.env.VITE_API_URL?.replace('/api/v1', '') || 'http://localhost:5000', {
+    const newSocket = io(import.meta.env.VITE_API_URL?.replace('/api/v1', '') || '', {
       auth: { token }
     });
 

--- a/client/src/contexts/NotificationContext.tsx
+++ b/client/src/contexts/NotificationContext.tsx
@@ -19,7 +19,7 @@ interface NotificationContextType {
 const NotificationContext = createContext<NotificationContextType | undefined>(undefined);
 
 // In a real app, this URL would come from an environment variable
-const SOCKET_URL = 'http://localhost:5000';
+const SOCKET_URL = import.meta.env.VITE_API_URL?.replace('/api/v1', '') || '';
 
 export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user } = useAuth();

--- a/client/src/pages/KanbanBoard.tsx
+++ b/client/src/pages/KanbanBoard.tsx
@@ -641,7 +641,7 @@ const KanbanBoard: React.FC =
     }, [loadRequests]);
 
     useEffect(() => {
-      const socket = io(import.meta.env.VITE_API_URL || "http://localhost:5000", {
+      const socket = io(import.meta.env.VITE_API_URL || "", {
         withCredentials: true,
       });
 

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -134,7 +134,7 @@ const LoginPage: React.FC = () => {
 
             <div className="mt-4 sm:mt-6 grid grid-cols-2 gap-2 sm:gap-3">
               <a
-                href={`${import.meta.env.VITE_API_URL || 'http://localhost:5000/api/v1'}/auth/google`}
+                href={`${import.meta.env.VITE_API_URL || '/api/v1'}/auth/google`}
                 className="w-full inline-flex justify-center py-2 sm:py-2.5 px-2 sm:px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm bg-white dark:bg-gray-700 text-xs sm:text-sm font-medium text-gray-500 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors"
               >
                 <span className="sr-only">Sign in with Google</span>
@@ -146,7 +146,7 @@ const LoginPage: React.FC = () => {
                 </svg>
               </a>
               <a
-                href={`${import.meta.env.VITE_API_URL || 'http://localhost:5000/api/v1'}/auth/microsoft`}
+                href={`${import.meta.env.VITE_API_URL || '/api/v1'}/auth/microsoft`}
                 className="w-full inline-flex justify-center py-2 sm:py-2.5 px-2 sm:px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm bg-white dark:bg-gray-700 text-xs sm:text-sm font-medium text-gray-500 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors"
               >
                 <span className="sr-only">Sign in with Microsoft</span>

--- a/client/src/pages/ToolCrib.tsx
+++ b/client/src/pages/ToolCrib.tsx
@@ -9,7 +9,7 @@ import toast from 'react-hot-toast';
 import api from '../services/api';
 import { io } from 'socket.io-client';
 
-const SOCKET_URL = import.meta.env.VITE_API_URL?.replace('/api/v1', '') || 'http://localhost:5000';
+const SOCKET_URL = import.meta.env.VITE_API_URL?.replace('/api/v1', '') || '';
 
 const ToolCrib: React.FC = () => {
   const { t } = useTranslation();

--- a/client/src/pages/VendorTicketView.tsx
+++ b/client/src/pages/VendorTicketView.tsx
@@ -5,6 +5,10 @@ import toast from 'react-hot-toast';
 import { MaintenanceRequest } from '../types';
 
 export default function VendorTicketView() {
+  const API_BASE = import.meta.env.VITE_API_URL || '';
+  const VENDOR_API_BASE = API_BASE ? API_BASE.replace('/api/v1', '/api/vendor') : '/api/vendor';
+  const MEDIA_BASE = API_BASE ? API_BASE.replace('/api/v1', '') : '';
+  
   const { token } = useParams<{ token: string }>();
   const [ticket, setTicket] = useState<MaintenanceRequest | null>(null);
   const [loading, setLoading] = useState(true);
@@ -14,7 +18,7 @@ export default function VendorTicketView() {
   useEffect(() => {
     const fetchTicket = async () => {
       try {
-        const response = await axios.get(`http://localhost:5001/api/vendor/ticket/${token}`);
+        const response = await axios.get(`${VENDOR_API_BASE}/ticket/${token}`);
         setTicket(response.data);
       } catch (err: any) {
         setError(err.response?.data?.error || "Failed to load ticket. The link may have expired.");
@@ -30,7 +34,7 @@ export default function VendorTicketView() {
     if (!noteContent.trim()) return;
 
     try {
-      const response = await axios.post(`http://localhost:5001/api/vendor/ticket/${token}/notes`, {
+      const response = await axios.post(`${VENDOR_API_BASE}/ticket/${token}/notes`, {
         content: noteContent
       });
       setTicket(prev => prev ? { ...prev, comments: [...(prev.comments || []), response.data] } : prev);
@@ -43,7 +47,7 @@ export default function VendorTicketView() {
 
   const handleMarkRepaired = async () => {
     try {
-      await axios.patch(`http://localhost:5001/api/vendor/ticket/${token}/stage`, {
+      await axios.patch(`${VENDOR_API_BASE}/ticket/${token}/stage`, {
         stage: 'repaired'
       });
       setTicket(prev => prev ? { ...prev, stage: 'repaired' } : prev);
@@ -61,7 +65,7 @@ export default function VendorTicketView() {
     files.forEach(file => formData.append('attachments', file));
 
     try {
-      const response = await axios.post(`http://localhost:5001/api/vendor/ticket/${token}/attachments`, formData, {
+      const response = await axios.post(`${VENDOR_API_BASE}/ticket/${token}/attachments`, formData, {
         headers: { 'Content-Type': 'multipart/form-data' }
       });
       setTicket(prev => prev ? { ...prev, attachments: [...(prev.attachments || []), ...response.data.attachments] } : prev);
@@ -237,7 +241,7 @@ export default function VendorTicketView() {
                       <svg className="w-4 h-4 mr-2 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
                       </svg>
-                      <a href={`http://localhost:5001${file.fileUrl}`} target="_blank" rel="noopener noreferrer" className="text-indigo-600 dark:text-indigo-400 hover:underline truncate">
+                      <a href={`${MEDIA_BASE}${file.fileUrl}`} target="_blank" rel="noopener noreferrer" className="text-indigo-600 dark:text-indigo-400 hover:underline truncate">
                         {file.filename}
                       </a>
                     </li>


### PR DESCRIPTION
## 📌 Pull Request Title

fix: Remove Hardcoded localhost URLs in the React Client

---

## 🚀 Description

This PR replaces dangerously hardcoded `http://localhost` URLs in the client codebase with dynamic environment variables, ensuring assets and API requests resolve correctly in production environments.

**Key Fixes Implemented:**
- **Dynamic Image Resolutions:** Updated `ImageGallery.tsx`, `RequestModal.tsx`, and `EquipmentDocumentsTab.tsx` to automatically construct absolute URLs for images and documents using the current `VITE_API_URL` base, allowing these assets to load seamlessly when deployed.
- **Vendor Portal Migration:** Stripped `http://localhost:5001` hardcodes across the `VendorTicketView.tsx` file, configuring it to dynamically target the deployment's `/api/vendor` base routes.
- **WebSocket & Auth Safeties:** Replaced fallback URLs (`|| 'http://localhost:5000'`) in Socket.io initializations (`KanbanBoard`, `TelemetryChart`, `ToolCrib`, etc.) and OAuth endpoints with relative paths so they don't break routing when `VITE_API_URL` is omitted in production setups.

---

## 🔗 Related Issue

Closes #464

---

## 📝 Changes Made

- [x] Stripped `localhost` from `client/src/contexts/NotificationContext.tsx`.
- [x] Handled image paths dynamically in `client/src/components/ImageGallery.tsx`.
- [x] Used dynamic environment logic in `client/src/components/RequestModal.tsx` and `client/src/components/EquipmentDocumentsTab.tsx`.
- [x] Refactored `client/src/pages/VendorTicketView.tsx` to utilize `API_BASE` and `VENDOR_API_BASE` constant definitions.
- [x] Sanitized fallback socket definitions across all remaining frontend modules.

---

## 🧪 Testing Performed

- [x] Verified local build completes successfully without missing environment variables.
- [x] Assessed that running `vite build` dynamically links fallback strings.

---

## ✅ Checklist

- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] This PR does not break existing functionality
- [x] I have added necessary documentation